### PR TITLE
feat: 软件卸载（类 Geek Uninstaller）+ 强力删除 + 卸载体验/图标优化

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -796,9 +796,11 @@ dependencies = [
 name = "disk-butler"
 version = "0.7.2"
 dependencies = [
+ "base64 0.22.1",
  "encoding_rs",
  "jwalk",
  "ntfs-reader",
+ "png 0.17.16",
  "rayon",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,8 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_SystemInformation",
     "Win32_System_Pipes",
     "Win32_System_IO",
+    "Win32_System_RestartManager",
+    "Win32_System_Threading",
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ sysinfo = "0.32"
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
     "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Graphics_Gdi",
     "Win32_System_Com",
     "Win32_System_SystemInformation",
     "Win32_System_Pipes",
@@ -43,6 +45,9 @@ encoding_rs = "0.8"
 ntfs-reader = "0.4"
 windows-service = "0.8"
 rayon = "1"
+# 应用图标提取：HICON -> PNG -> base64 data URI
+png = "0.17"
+base64 = "0.22"
 
 [profile.dev]
 # 加快扫描相关依赖的运行速度；关闭调试信息以降低编译内存峰值（16GB 内存机器必需）

--- a/src-tauri/src/force_delete.rs
+++ b/src-tauri/src/force_delete.rs
@@ -1,0 +1,698 @@
+//! 强力删除：定位占用文件/文件夹的进程，可选终止后删除。
+//! 定位主用 NtQueryInformationFile(FileProcessIdsUsingFileInformation)——Restart Manager 内部同款，
+//! 打开目标句柄直接问内核谁在用它，确定/快速/不卡死；再叠加 Restart Manager 兜底。
+//! 终止优先 TerminateProcess（普通权限），被拒的进程再用一次提权 taskkill 兜底。
+
+use serde::Serialize;
+use std::ffi::c_void;
+use std::path::Path;
+
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// 占用某路径的进程信息。
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LockingProcess {
+    pub pid: u32,
+    pub name: String,
+    /// 系统关键进程：终止会导致系统崩溃/重启，前端禁止勾选、后端也拒绝终止。
+    pub is_critical: bool,
+}
+
+/// 系统关键进程名（小写，可含 .exe）：一律禁止终止。
+/// 含 explorer（桌面外壳，关了会黑屏）与会导致系统崩溃/重启的核心进程。
+fn is_critical_name(name_lower: &str) -> bool {
+    let n = name_lower.strip_suffix(".exe").unwrap_or(name_lower);
+    matches!(
+        n,
+        "system"
+            | "system idle process"
+            | "smss"
+            | "csrss"
+            | "wininit"
+            | "winlogon"
+            | "services"
+            | "lsass"
+            | "lsaiso"
+            | "fontdrvhost"
+            | "dwm"
+            | "svchost"
+            | "explorer"
+            | "taskhostw"
+            | "ctfmon"
+            | "sihost"
+    )
+}
+
+fn current_pid() -> u32 {
+    std::process::id()
+}
+
+fn wstr_to_string(buf: &[u16]) -> String {
+    let end = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    String::from_utf16_lossy(&buf[..end])
+}
+
+/// 查找占用指定文件/文件夹的进程。
+/// 主方法：NtQueryInformationFile(FileProcessIdsUsingFileInformation)——打开目标句柄直接问内核
+/// “哪些进程在用它”（Restart Manager 内部同款），确定性、无需全系统扫描、不卡死；
+/// 目录会额外查其中文件。再叠加 Restart Manager 兜底。
+pub fn find_lockers(path: &str) -> Vec<LockingProcess> {
+    use std::collections::HashMap;
+    let p = Path::new(path);
+    if !p.exists() {
+        return Vec::new();
+    }
+
+    // 目标本体 +（若是目录）其中文件，逐个查占用
+    let mut targets: Vec<String> = vec![path.to_string()];
+    if p.is_dir() {
+        collect_files(p, &mut targets, 400);
+    }
+
+    let mut map: HashMap<u32, LockingProcess> = HashMap::new();
+    let me = current_pid();
+
+    // 1) 主方法：文件对象的占用进程 PID 列表
+    for t in &targets {
+        for pid in nt_file_lockers(t) {
+            if pid == 0 || pid == me || map.contains_key(&pid) {
+                continue;
+            }
+            if let Some(name) = process_name(pid) {
+                let is_critical = is_critical_name(&name.to_lowercase());
+                map.insert(
+                    pid,
+                    LockingProcess {
+                        pid,
+                        name,
+                        is_critical,
+                    },
+                );
+            }
+        }
+    }
+
+    // 2) Restart Manager 兜底（登记文件，补充主方法可能遗漏的锁定者）
+    for lp in rm_find(&targets) {
+        map.entry(lp.pid).or_insert(lp);
+    }
+
+    let mut result: Vec<LockingProcess> = map.into_values().collect();
+    result.sort_by(|a, b| {
+        a.name
+            .to_lowercase()
+            .cmp(&b.name.to_lowercase())
+            .then(a.pid.cmp(&b.pid))
+    });
+    result
+}
+
+/// 递归收集目录下的文件路径（限量，避免病态大目录拖慢）。
+fn collect_files(dir: &Path, out: &mut Vec<String>, cap: usize) {
+    if out.len() >= cap {
+        return;
+    }
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for e in rd.flatten() {
+        if out.len() >= cap {
+            return;
+        }
+        let path = e.path();
+        if path.is_dir() {
+            collect_files(&path, out, cap);
+        } else {
+            out.push(path.to_string_lossy().to_string());
+        }
+    }
+}
+
+/// Restart Manager 查询占用给定文件的进程。
+fn rm_find(files: &[String]) -> Vec<LockingProcess> {
+    use windows_sys::Win32::System::RestartManager::{
+        RmEndSession, RmGetList, RmRegisterResources, RmStartSession, RM_PROCESS_INFO,
+    };
+    unsafe {
+        let mut session: u32 = 0;
+        let mut key = [0u16; 64]; // CCH_RM_SESSION_KEY(32)+1，放大冗余
+        if RmStartSession(&mut session, 0, key.as_mut_ptr()) != 0 {
+            return Vec::new();
+        }
+        // 组装文件名宽字符指针数组（wides 必须存活到调用结束）
+        let wides: Vec<Vec<u16>> = files
+            .iter()
+            .map(|f| f.encode_utf16().chain(std::iter::once(0)).collect())
+            .collect();
+        let ptrs: Vec<*const u16> = wides.iter().map(|w| w.as_ptr()).collect();
+        let reg = RmRegisterResources(
+            session,
+            ptrs.len() as u32,
+            ptrs.as_ptr(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+        );
+        if reg != 0 {
+            RmEndSession(session);
+            return Vec::new();
+        }
+        // 先查数量，再取列表
+        let mut needed: u32 = 0;
+        let mut count: u32 = 0;
+        let mut reason: u32 = 0;
+        RmGetList(
+            session,
+            &mut needed,
+            &mut count,
+            std::ptr::null_mut(),
+            &mut reason,
+        );
+        let mut result: Vec<LockingProcess> = Vec::new();
+        if needed > 0 {
+            let mut infos: Vec<RM_PROCESS_INFO> = vec![std::mem::zeroed(); needed as usize];
+            count = needed;
+            let r = RmGetList(
+                session,
+                &mut needed,
+                &mut count,
+                infos.as_mut_ptr(),
+                &mut reason,
+            );
+            if r == 0 {
+                let me = current_pid();
+                for info in infos.iter().take(count as usize) {
+                    let pid = info.Process.dwProcessId;
+                    if pid == 0 || pid == me {
+                        continue;
+                    }
+                    let name = wstr_to_string(&info.strAppName);
+                    let is_critical = is_critical_name(&name.to_lowercase());
+                    result.push(LockingProcess {
+                        pid,
+                        name,
+                        is_critical,
+                    });
+                }
+            }
+        }
+        RmEndSession(session);
+        // 去重（同一进程可能锁多个文件）
+        result.sort_by_key(|p| p.pid);
+        result.dedup_by_key(|p| p.pid);
+        result
+    }
+}
+
+/// 解除占用并删除路径。升级策略：关句柄+立即删（抢在监视器重开前，重试）→ 结束整个占用应用 → 再删。
+/// to_recycle=true 走回收站(可恢复)，否则永久删除。
+pub fn force_delete(path: &str, pids: Vec<u32>, to_recycle: bool) -> Result<(), String> {
+    let target_nt = dos_to_nt(&path.trim_end_matches(['\\', '/']).to_lowercase());
+
+    // 1) 关句柄 + 立即删（不 sleep，抢在监视器重新打开前），重试几次——顺利时无需杀进程
+    if let Some(tn) = target_nt.as_ref() {
+        let sub = format!("{}\\", tn);
+        for _ in 0..4 {
+            let mut closed = 0usize;
+            for &pid in &pids {
+                if pid == 0 || pid == current_pid() {
+                    continue;
+                }
+                closed += close_handles_to(pid, tn, &sub);
+            }
+            if delete_path(path, to_recycle).is_ok() {
+                return Ok(());
+            }
+            if closed == 0 {
+                break; // 没句柄可关，重试无意义
+            }
+        }
+    }
+
+    // 2) 仍被占用 → 结束整个占用应用（按映像名结束其全部进程，等价资源监视器/任务管理器“结束进程树”），再删
+    kill_locker_apps(&pids)?;
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    delete_path(path, to_recycle)
+}
+
+/// 结束占用文件的整个应用：把选中进程的（非关键）映像名整体 taskkill /F /T（含其全部进程及子树），
+/// 等价资源监视器“结束进程”。只杀部分子进程会被主进程重开，故按映像名整体结束才可靠。
+fn kill_locker_apps(pids: &[u32]) -> Result<(), String> {
+    use std::collections::HashSet;
+    use std::os::windows::process::CommandExt;
+    let mut names: HashSet<String> = HashSet::new();
+    for &pid in pids {
+        if pid == 0 || pid == current_pid() {
+            continue;
+        }
+        if let Some(name) = process_name(pid) {
+            // 防御：绝不结束系统关键进程（如 explorer，关了会黑屏）
+            if is_critical_name(&name.to_lowercase()) {
+                continue;
+            }
+            names.insert(name);
+        }
+    }
+    if names.is_empty() {
+        return Ok(());
+    }
+    let mut args: Vec<String> = vec!["/F".to_string(), "/T".to_string()];
+    for n in &names {
+        args.push("/IM".to_string());
+        args.push(n.clone());
+    }
+    // 普通权限 taskkill 对同用户进程即可结束；部分失败不致命（子进程随主进程一起结束）
+    let _ = std::process::Command::new("taskkill")
+        .args(&args)
+        .creation_flags(CREATE_NO_WINDOW)
+        .status();
+    Ok(())
+}
+
+/// 删除路径：回收站(可恢复) 或 永久删除；永久删除失败时提权兜底。
+fn delete_path(path: &str, to_recycle: bool) -> Result<(), String> {
+    let p = Path::new(path);
+    if !p.exists() {
+        return Ok(()); // 已不存在，视作成功
+    }
+    if to_recycle {
+        return send_to_recycle(path);
+    }
+    let r = if p.is_dir() {
+        std::fs::remove_dir_all(p)
+    } else {
+        std::fs::remove_file(p)
+    };
+    match r {
+        Ok(()) => Ok(()),
+        Err(_) => elevated_delete(path, p.is_dir()), // 受保护 → 提权删除
+    }
+}
+
+/// 删入回收站（可恢复），文件/文件夹通用。
+fn send_to_recycle(path: &str) -> Result<(), String> {
+    use windows_sys::Win32::UI::Shell::{SHFileOperationW, SHFILEOPSTRUCTW};
+    const FO_DELETE: u32 = 0x0003;
+    const FOF_SILENT: u16 = 0x0004;
+    const FOF_NOCONFIRMATION: u16 = 0x0010;
+    const FOF_ALLOWUNDO: u16 = 0x0040;
+    const FOF_NOERRORUI: u16 = 0x0400;
+
+    let mut from: Vec<u16> = path.encode_utf16().collect();
+    from.push(0);
+    from.push(0);
+
+    let mut op = SHFILEOPSTRUCTW {
+        hwnd: std::ptr::null_mut(),
+        wFunc: FO_DELETE,
+        pFrom: from.as_ptr(),
+        pTo: std::ptr::null(),
+        fFlags: FOF_ALLOWUNDO | FOF_NOCONFIRMATION | FOF_SILENT | FOF_NOERRORUI,
+        fAnyOperationsAborted: 0,
+        hNameMappings: std::ptr::null_mut(),
+        lpszProgressTitle: std::ptr::null(),
+    };
+    let ret = unsafe { SHFileOperationW(&mut op) };
+    if ret == 0 && op.fAnyOperationsAborted == 0 {
+        Ok(())
+    } else {
+        Err(format!("移入回收站失败 (code={})", ret))
+    }
+}
+
+/// 提权永久删除（受保护路径兜底，单次 UAC，隐藏窗口）。
+fn elevated_delete(path: &str, is_dir: bool) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    let cmd = if is_dir {
+        format!(r#"rmdir /s /q "{}""#, path.trim_end_matches('\\'))
+    } else {
+        format!(r#"del /f /q "{}""#, path)
+    };
+    // 作为单个参数传给 cmd /c（PowerShell 单引号字符串，内部单引号转义为两个）
+    let quoted = format!("'{}'", cmd.replace('\'', "''"));
+    let ps = format!(
+        r#"$p = Start-Process -Verb RunAs -WindowStyle Hidden -Wait -PassThru -FilePath cmd.exe -ArgumentList '/c',{}; exit $p.ExitCode"#,
+        quoted
+    );
+    let status = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", &ps])
+        .creation_flags(CREATE_NO_WINDOW)
+        .status()
+        .map_err(|e| format!("提权删除失败：{}", e))?;
+    match status.code().unwrap_or(-1) {
+        0 => {
+            if Path::new(path).exists() {
+                Err("删除未完成（文件可能仍被占用）。".to_string())
+            } else {
+                Ok(())
+            }
+        }
+        1 => Err("已取消管理员授权，未删除。".to_string()),
+        c => Err(format!("提权删除未完成（退出码 {}）。", c)),
+    }
+}
+
+/// 计划在下次重启时删除（MoveFileEx + MOVEFILE_DELAY_UNTIL_REBOOT，微软更新占用文件同款）。
+/// 目录需递归登记（深层优先）；写 PendingFileRenameOperations 需管理员，故提权执行，弹一次 UAC。
+#[allow(dead_code)]
+fn schedule_reboot_delete(path: &str) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    // 内层脚本：递归深层优先登记每个文件/子目录，最后登记目标本身（MOVEFILE_DELAY_UNTIL_REBOOT=4）
+    let script = format!(
+        "Add-Type -Namespace N -Name F -MemberDefinition '[DllImport(\"kernel32.dll\",CharSet=CharSet.Unicode,SetLastError=true)] public static extern bool MoveFileEx(string a, string b, int f);'\r\n\
+$t = '{}'\r\n\
+Get-ChildItem -LiteralPath $t -Recurse -Force -ErrorAction SilentlyContinue | Sort-Object {{ $_.FullName.Length }} -Descending | ForEach-Object {{ [N.F]::MoveFileEx($_.FullName, $null, 4) | Out-Null }}\r\n\
+[N.F]::MoveFileEx($t, $null, 4) | Out-Null\r\n",
+        path.replace('\'', "''")
+    );
+    let tmp = std::env::temp_dir().join(format!("db-reboot-del-{}.ps1", std::process::id()));
+    // UTF-8 BOM 保证 PowerShell 正确读取中文路径
+    let mut bytes = vec![0xEFu8, 0xBB, 0xBF];
+    bytes.extend_from_slice(script.as_bytes());
+    std::fs::write(&tmp, &bytes).map_err(|e| format!("写入计划删除脚本失败：{}", e))?;
+    let ps = format!(
+        r#"$p = Start-Process -Verb RunAs -WindowStyle Hidden -Wait -PassThru -FilePath powershell.exe -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','"{}"'; exit $p.ExitCode"#,
+        tmp.display()
+    );
+    let status = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", &ps])
+        .creation_flags(CREATE_NO_WINDOW)
+        .status()
+        .map_err(|e| format!("提权计划删除失败：{}", e))?;
+    let _ = std::fs::remove_file(&tmp);
+    match status.code().unwrap_or(-1) {
+        0 => Ok(()),
+        1 => Err("已取消管理员授权，未计划删除。".to_string()),
+        c => Err(format!("计划重启删除未完成（退出码 {}）。", c)),
+    }
+}
+
+// ---------- NT 文件占用查询（Restart Manager 内部同款：直接问内核谁在用该文件对象） ----------
+
+#[link(name = "ntdll")]
+extern "system" {
+    fn NtQueryInformationFile(
+        handle: *mut c_void,
+        io: *mut IoStatusBlock,
+        info: *mut c_void,
+        len: u32,
+        class: u32,
+    ) -> i32;
+}
+
+#[repr(C)]
+struct IoStatusBlock {
+    status_or_pointer: usize,
+    information: usize,
+}
+
+/// 打开一个仅用于查询的句柄（读属性 + 全共享，即便文件/目录被占用也能打开）。失败返回 null。
+fn open_query_handle(path: &str) -> *mut c_void {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    let wide: Vec<u16> = Path::new(path)
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let h = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS, // 打开目录句柄必需
+            std::ptr::null_mut(),
+        )
+    };
+    if h == INVALID_HANDLE_VALUE {
+        std::ptr::null_mut()
+    } else {
+        h
+    }
+}
+
+/// 查询正在使用某文件/目录的进程 PID 列表（FileProcessIdsUsingFileInformation=47）。
+/// 打开目标句柄后由内核直接返回，确定、快速、无需枚举全系统句柄、不卡死。
+fn nt_file_lockers(path: &str) -> Vec<u32> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    const FILE_PROCESS_IDS_USING_FILE_INFORMATION: u32 = 47;
+
+    let h = open_query_handle(path);
+    if h.is_null() {
+        return Vec::new();
+    }
+    let mut result = Vec::new();
+    // 缓冲区：count(4字节+对齐) + PID 数组，4KB 足以容纳数百个 PID
+    let mut buf = vec![0u8; 4096];
+    let mut io = IoStatusBlock {
+        status_or_pointer: 0,
+        information: 0,
+    };
+    let status = unsafe {
+        NtQueryInformationFile(
+            h,
+            &mut io,
+            buf.as_mut_ptr() as *mut c_void,
+            buf.len() as u32,
+            FILE_PROCESS_IDS_USING_FILE_INFORMATION,
+        )
+    };
+    unsafe { CloseHandle(h) };
+    if status < 0 {
+        return result;
+    }
+    // FILE_PROCESS_IDS_USING_FILE_INFORMATION: ULONG NumberOfProcessIdsInList; ULONG_PTR ProcessIdList[];
+    // 64 位下 ProcessIdList 按 8 字节对齐，紧跟在偏移 8（=size_of::<usize>）处
+    unsafe {
+        let count = *(buf.as_ptr() as *const u32) as usize;
+        let list = (buf.as_ptr() as usize + std::mem::size_of::<usize>()) as *const usize;
+        let max = (buf.len() - std::mem::size_of::<usize>()) / std::mem::size_of::<usize>();
+        for i in 0..count.min(max) {
+            let pid = *list.add(i) as u32;
+            if pid != 0 {
+                result.push(pid);
+            }
+        }
+    }
+    result
+}
+
+/// 取进程可执行文件名（如 Code.exe）。
+fn process_name(pid: u32) -> Option<String> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, QueryFullProcessImageNameW, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    unsafe {
+        let h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if h.is_null() {
+            return None;
+        }
+        let mut buf = [0u16; 260];
+        let mut size = buf.len() as u32;
+        let ok = QueryFullProcessImageNameW(h, 0, buf.as_mut_ptr(), &mut size);
+        CloseHandle(h);
+        if ok == 0 {
+            return None;
+        }
+        let full = String::from_utf16_lossy(&buf[..size as usize]);
+        Some(full.rsplit(['\\', '/']).next().unwrap_or(&full).to_string())
+    }
+}
+
+// ---------- 关闭远程句柄解除占用（LockHunter/Unlocker 同款：不杀进程即可释放锁） ----------
+
+#[link(name = "ntdll")]
+extern "system" {
+    fn NtQueryObject(handle: *mut c_void, class: u32, info: *mut c_void, len: u32, ret: *mut u32)
+        -> i32;
+    fn NtQueryInformationProcess(
+        handle: *mut c_void,
+        class: u32,
+        info: *mut c_void,
+        len: u32,
+        ret: *mut u32,
+    ) -> i32;
+}
+#[link(name = "kernel32")]
+extern "system" {
+    fn QueryDosDeviceW(device: *const u16, target: *mut u16, max: u32) -> u32;
+}
+
+#[repr(C)]
+struct UnicodeString {
+    length: u16,
+    maximum_length: u16,
+    buffer: *mut u16,
+}
+
+#[repr(C)]
+struct ProcHandleEntry {
+    handle_value: usize,
+    handle_count: usize,
+    pointer_count: usize,
+    granted_access: u32,
+    object_type_index: u32,
+    handle_attributes: u32,
+    reserved: u32,
+}
+
+/// DOS 路径（小写，如 d:\a\b）转 NT 设备路径前缀（小写，如 \device\harddiskvolume3\a\b）。
+fn dos_to_nt(dos_lower: &str) -> Option<String> {
+    if dos_lower.len() < 2 || dos_lower.as_bytes()[1] != b':' {
+        return None;
+    }
+    let drive = &dos_lower[..2];
+    let rest = &dos_lower[2..];
+    let wdrive: Vec<u16> = drive.encode_utf16().chain(std::iter::once(0)).collect();
+    let mut buf = [0u16; 512];
+    let n = unsafe { QueryDosDeviceW(wdrive.as_ptr(), buf.as_mut_ptr(), buf.len() as u32) };
+    if n == 0 {
+        return None;
+    }
+    let dev = wstr_to_string(&buf);
+    if dev.is_empty() {
+        return None;
+    }
+    Some(format!("{}{}", dev.to_lowercase(), rest))
+}
+
+/// 查询本进程内复制句柄的对象名（\Device\HarddiskVolumeX\...）。
+unsafe fn query_object_name(h: *mut c_void) -> Option<String> {
+    const OBJECT_NAME_INFORMATION: u32 = 1;
+    let mut buf = [0u8; 4096];
+    let mut ret: u32 = 0;
+    let status = NtQueryObject(
+        h,
+        OBJECT_NAME_INFORMATION,
+        buf.as_mut_ptr() as *mut c_void,
+        buf.len() as u32,
+        &mut ret,
+    );
+    if status < 0 {
+        return None;
+    }
+    let us = &*(buf.as_ptr() as *const UnicodeString);
+    if us.length == 0 || us.buffer.is_null() {
+        return None;
+    }
+    let slice = std::slice::from_raw_parts(us.buffer, (us.length / 2) as usize);
+    Some(String::from_utf16_lossy(slice))
+}
+
+/// 枚举指定进程的句柄（NtQueryInformationProcess(ProcessHandleInformation=51)）。返回 (句柄值, 授权掌码)。
+fn enum_process_handles(proc: *mut c_void) -> Vec<(usize, u32)> {
+    const PROCESS_HANDLE_INFORMATION: u32 = 51;
+    const STATUS_INFO_LENGTH_MISMATCH: i32 = 0xC000_0004u32 as i32;
+    let mut cap: usize = 64 * 1024;
+    loop {
+        let mut buf = vec![0u8; cap];
+        let mut ret: u32 = 0;
+        let status = unsafe {
+            NtQueryInformationProcess(
+                proc,
+                PROCESS_HANDLE_INFORMATION,
+                buf.as_mut_ptr() as *mut c_void,
+                cap as u32,
+                &mut ret,
+            )
+        };
+        if status == STATUS_INFO_LENGTH_MISMATCH {
+            cap = (cap * 2).min(64 << 20);
+            if cap >= (64 << 20) {
+                return Vec::new();
+            }
+            continue;
+        }
+        if status < 0 {
+            return Vec::new();
+        }
+        unsafe {
+            let count = *(buf.as_ptr() as *const usize);
+            let entries =
+                (buf.as_ptr() as usize + 2 * std::mem::size_of::<usize>()) as *const ProcHandleEntry;
+            let mut out = Vec::with_capacity(count.min(200_000));
+            for i in 0..count.min(200_000) {
+                let e = &*entries.add(i);
+                out.push((e.handle_value, e.granted_access));
+            }
+            return out;
+        }
+    }
+}
+
+/// 关闭目标进程中指向 target_nt（或其子路径）的句柄，解除占用而不杀进程。返回关闭数。
+fn close_handles_to(pid: u32, target_nt: &str, target_nt_sub: &str) -> usize {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, DuplicateHandle, DUPLICATE_CLOSE_SOURCE, DUPLICATE_SAME_ACCESS,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcess, PROCESS_DUP_HANDLE};
+    let src = unsafe { OpenProcess(PROCESS_DUP_HANDLE, 0, pid) };
+    if src.is_null() {
+        return 0;
+    }
+    let cur = unsafe { GetCurrentProcess() };
+    let mut closed = 0usize;
+    for (hv, ga) in enum_process_handles(src) {
+        if ga == 0x0012_019F {
+            continue; // 跳过会让 NtQueryObject 卡死的同步句柄
+        }
+        // 先复制一份来查名字
+        let mut dup: *mut c_void = std::ptr::null_mut();
+        let ok =
+            unsafe { DuplicateHandle(src, hv as *mut c_void, cur, &mut dup, 0, 0, DUPLICATE_SAME_ACCESS) };
+        if ok == 0 || dup.is_null() {
+            continue;
+        }
+        let name = unsafe { query_object_name(dup) };
+        unsafe { CloseHandle(dup) };
+        let Some(name) = name else {
+            continue;
+        };
+        let nl = name.to_lowercase();
+        if nl == target_nt || nl.starts_with(target_nt_sub) {
+            // 命中：DUPLICATE_CLOSE_SOURCE 关闭源进程里的该句柄
+            let mut d2: *mut c_void = std::ptr::null_mut();
+            let ok2 = unsafe {
+                DuplicateHandle(src, hv as *mut c_void, cur, &mut d2, 0, 0, DUPLICATE_CLOSE_SOURCE)
+            };
+            if ok2 != 0 {
+                if !d2.is_null() {
+                    unsafe { CloseHandle(d2) };
+                }
+                closed += 1;
+            }
+        }
+    }
+    unsafe { CloseHandle(src) };
+    closed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn critical_names_detected() {
+        assert!(is_critical_name("csrss.exe"));
+        assert!(is_critical_name("lsass"));
+        assert!(is_critical_name("system"));
+        assert!(is_critical_name("explorer.exe"));
+        assert!(!is_critical_name("chrome.exe"));
+        assert!(!is_critical_name("qq.exe"));
+    }
+
+    #[test]
+    fn wstr_stops_at_nul() {
+        let buf = [0x41u16, 0x42, 0x00, 0x43];
+        assert_eq!(wstr_to_string(&buf), "AB");
+    }
+}

--- a/src-tauri/src/icon.rs
+++ b/src-tauri/src/icon.rs
@@ -1,0 +1,544 @@
+//! 应用图标提取：优先用 DisplayIcon(路径,索引)，其次 MSI 产品图标，再退回安装目录/卸载器主 exe
+//! （Geek Uninstaller / BCUninstaller 同款兑底思路）。统一经 GDI 转 32bpp RGBA，编码 PNG 后返回 base64 data URI。
+
+use base64::Engine;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ};
+use winreg::RegKey;
+
+/// 尝试从一个图标文件（exe/dll/ico，支持索引）提取：
+/// 先 ExtractIconEx（PE/DLL），再 LoadImage 按文件加载 ICO（治后缀骗人的原始 .ico，如 MSI 的 ResolveIcon.exe），最后退 Shell 图标。
+fn try_icon_file(path: &str, idx: i32) -> Option<(u32, u32, Vec<u8>)> {
+    let p = expand_env(path);
+    if p.is_empty() || !Path::new(&p).exists() {
+        return None;
+    }
+    if let Some(r) = extract_icon_rgba(&p, idx) {
+        return Some(r);
+    }
+    if let Some(r) = load_ico_file(&p) {
+        return Some(r);
+    }
+    shell_icon_rgba(&p)
+}
+
+/// 用 LoadImageW 按文件加载 ICO（LR_LOADFROMFILE），不看扩展名按内容解析，
+/// 专治那些后缀名不对的原始 .ico（MSI 产品图标常见：*.exe / 无扩展名）。
+fn load_ico_file(path: &str) -> Option<(u32, u32, Vec<u8>)> {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{DestroyIcon, LoadImageW};
+    const IMAGE_ICON: u32 = 1;
+    const LR_LOADFROMFILE: u32 = 0x0000_0010;
+    const LR_DEFAULTSIZE: u32 = 0x0000_0040;
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    unsafe {
+        let h = LoadImageW(
+            std::ptr::null_mut(),
+            wide.as_ptr(),
+            IMAGE_ICON,
+            0,
+            0,
+            LR_LOADFROMFILE | LR_DEFAULTSIZE,
+        );
+        if h.is_null() {
+            return None;
+        }
+        let out = hicon_to_rgba(h as _);
+        DestroyIcon(h as _);
+        out
+    }
+}
+
+/// 按 ProductName 在 MSI 产品表里查 ProductIcon（很多 MSI 软件 DisplayIcon/InstallLocation 为空，
+/// 图标只存于 HKLM\SOFTWARE\Classes\Installer\Products\<PackedGUID>\ProductIcon，指向 C:\Windows\Installer\{GUID}\*.ico|exe）。
+fn msi_product_icon(display_name: &str) -> Option<(String, i32)> {
+    let target = display_name.trim().to_lowercase();
+    if target.is_empty() {
+        return None;
+    }
+    let sources = [
+        (HKEY_LOCAL_MACHINE, r"SOFTWARE\Classes\Installer\Products"),
+        (HKEY_CURRENT_USER, r"SOFTWARE\Microsoft\Installer\Products"),
+    ];
+    for (hive, path) in sources {
+        let Ok(root) = RegKey::predef(hive).open_subkey_with_flags(path, KEY_READ) else {
+            continue;
+        };
+        for sub in root.enum_keys().flatten() {
+            let Ok(k) = root.open_subkey_with_flags(&sub, KEY_READ) else {
+                continue;
+            };
+            let pn: String = k.get_value("ProductName").unwrap_or_default();
+            if pn.trim().to_lowercase() != target {
+                continue;
+            }
+            let icon: String = k.get_value("ProductIcon").unwrap_or_default();
+            if icon.trim().is_empty() {
+                continue;
+            }
+            return parse_display_icon(&icon);
+        }
+    }
+    None
+}
+
+/// 解析 DisplayIcon 并按兑底链取图标，编码为 `data:image/png;base64,...`。失败返回 None。
+pub fn icon_data_uri(
+    display_icon: &str,
+    install_location: &str,
+    uninstall_string: &str,
+    display_name: &str,
+) -> Option<String> {
+    // UWP/直接图片：DisplayIcon 指向 png/jpg 时直接读文件返回（UWP 包内 logo 为 png，不走 GDI 图标管线）
+    if let Some((p, _)) = parse_display_icon(display_icon) {
+        let pe = expand_env(&p);
+        let low = pe.to_lowercase();
+        if (low.ends_with(".png") || low.ends_with(".jpg") || low.ends_with(".jpeg"))
+            && Path::new(&pe).exists()
+        {
+            if let Ok(bytes) = std::fs::read(&pe) {
+                let mime = if low.ends_with(".png") { "image/png" } else { "image/jpeg" };
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                return Some(format!("data:{};base64,{}", mime, b64));
+            }
+        }
+    }
+    let rgba = resolve_icon(display_icon, install_location, uninstall_string, display_name)?;
+    let png: Vec<u8> = encode_png(rgba.0, rgba.1, &rgba.2)?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&png);
+    Some(format!("data:image/png;base64,{}", b64))
+}
+
+/// 展开路径中的 %ENV% 环境变量（DisplayIcon 偶尔写成 %ProgramFiles%\...）。
+fn expand_env(s: &str) -> String {
+    let mut out = String::new();
+    let mut rest = s;
+    while let Some(start) = rest.find('%') {
+        out.push_str(&rest[..start]);
+        if let Some(end_rel) = rest[start + 1..].find('%') {
+            let var = &rest[start + 1..start + 1 + end_rel];
+            match std::env::var(var) {
+                Ok(val) => out.push_str(&val),
+                Err(_) => {
+                    out.push('%');
+                    out.push_str(var);
+                    out.push('%');
+                }
+            }
+            rest = &rest[start + 1 + end_rel + 1..];
+        } else {
+            out.push_str(&rest[start..]);
+            return out;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// 从 UninstallString 里抽出卸载器 exe 路径（取首个 .exe token，支持引号包裹）。
+fn uninstaller_exe(uninstall_string: &str) -> Option<String> {
+    let s = expand_env(uninstall_string.trim());
+    if s.is_empty() {
+        return None;
+    }
+    // 引号包裹：取首对引号内容
+    if let Some(rest) = s.strip_prefix('"') {
+        if let Some(end) = rest.find('"') {
+            return Some(rest[..end].to_string());
+        }
+    }
+    // 无引号：取到 ".exe" 为止（大小写不敏感）
+    let lower = s.to_lowercase();
+    if let Some(pos) = lower.find(".exe") {
+        return Some(s[..pos + 4].to_string());
+    }
+    None
+}
+
+/// 兑底链（按优先级依次尝试，命中即返，避免不必要的注册表枚举）：
+/// DisplayIcon 及其同目录主 exe → MSI 产品图标 → 安装目录主 exe → 卸载器目录主 exe / 卸载器本体。
+fn resolve_icon(
+    display_icon: &str,
+    install_location: &str,
+    uninstall_string: &str,
+    display_name: &str,
+) -> Option<(u32, u32, Vec<u8>)> {
+    // 1) DisplayIcon 本体 + 其所在目录的主 exe
+    if let Some((path, index)) = parse_display_icon(display_icon) {
+        let path = expand_env(&path);
+        if let Some(r) = try_icon_file(&path, index) {
+            return Some(r);
+        }
+        if let Some(dir) = Path::new(&path).parent() {
+            if let Some(exe) = main_exe_in(&dir.to_string_lossy()) {
+                if let Some(r) = try_icon_file(&exe, 0) {
+                    return Some(r);
+                }
+            }
+        }
+    }
+    // 2) MSI 产品图标（多数 DisplayIcon 为空的 MSI 软件靠这一步）
+    if let Some((p, idx)) = msi_product_icon(display_name) {
+        if let Some(r) = try_icon_file(&p, idx) {
+            return Some(r);
+        }
+    }
+    // 3) 安装目录主 exe
+    let inst = expand_env(install_location.trim());
+    if !inst.is_empty() {
+        if let Some(exe) = main_exe_in(&inst) {
+            if let Some(r) = try_icon_file(&exe, 0) {
+                return Some(r);
+            }
+        }
+    }
+    // 4) 卸载器所在目录主 exe，以及卸载器本体（很多软件只有 UninstallString）
+    if let Some(u) = uninstaller_exe(uninstall_string) {
+        if let Some(dir) = Path::new(&u).parent() {
+            if let Some(exe) = main_exe_in(&dir.to_string_lossy()) {
+                if let Some(r) = try_icon_file(&exe, 0) {
+                    return Some(r);
+                }
+            }
+        }
+        if let Some(r) = try_icon_file(&u, 0) {
+            return Some(r);
+        }
+    }
+    None
+}
+
+/// 解析 `"C:\App\a.exe",0` → (路径, 索引)。无逗号索引则为 0。
+fn parse_display_icon(raw: &str) -> Option<(String, i32)> {
+    let s = raw.trim();
+    if s.is_empty() {
+        return None;
+    }
+    // 从右找逗号，且逗号后是整数才当索引（避免误伤路径里的逗号）
+    if let Some(i) = s.rfind(',') {
+        let tail = s[i + 1..].trim();
+        if let Ok(idx) = tail.parse::<i32>() {
+            let path = s[..i].trim().trim_matches('"').to_string();
+            return Some((path, idx));
+        }
+    }
+    Some((s.trim_matches('"').to_string(), 0))
+}
+
+/// 共享/系统目录（C:\Windows、System32、Program Files 根、盘符根等）：不得在其中“猜主程序”，
+/// 否则会把 explorer.exe 等系统程序的图标误当成软件图标。
+fn is_shared_root(dir: &str) -> bool {
+    let d = dir.trim().trim_end_matches(['\\', '/']).to_lowercase();
+    if d.is_empty() {
+        return true;
+    }
+    // 盘符根，如 c: 或 c:\
+    if d.len() <= 3 && d.as_bytes().get(1) == Some(&b':') {
+        return true;
+    }
+    let norm_var = |var: &str| {
+        std::env::var_os(var)
+            .map(|v| v.to_string_lossy().trim_end_matches(['\\', '/']).to_lowercase())
+            .unwrap_or_default()
+    };
+    for var in ["SystemRoot", "ProgramFiles", "ProgramFiles(x86)", "ProgramW6432", "ProgramData"] {
+        let r = norm_var(var);
+        if !r.is_empty() && d == r {
+            return true;
+        }
+    }
+    let sr = norm_var("SystemRoot");
+    if !sr.is_empty() && (d == format!("{}\\system32", sr) || d == format!("{}\\syswow64", sr)) {
+        return true;
+    }
+    false
+}
+
+/// 在安装目录里挑主程序 exe：扫目录本身、bin 子目录、以及每个一级子目录
+/// （很多软件把主 exe 嵌在子目录，如 Adobe：InstallLocation\Acrobat\Acrobat.exe）。
+/// 优先名字与目录名相关的 exe，其次体积最大。
+fn main_exe_in(dir: &str) -> Option<String> {
+    if is_shared_root(dir) {
+        return None;
+    }
+    let base = Path::new(dir);
+    let folder = base
+        .file_name()
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+    let first_word = folder.split_whitespace().next().unwrap_or("").to_string();
+
+    // 待扫目录：自身 + bin + 一级子目录（限量，避免病态大目录）
+    let mut dirs: Vec<PathBuf> = vec![base.to_path_buf(), base.join("bin")];
+    if let Ok(rd) = std::fs::read_dir(base) {
+        for e in rd.flatten().take(80) {
+            if e.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                dirs.push(e.path());
+            }
+        }
+    }
+
+    let mut best: Option<(u64, PathBuf)> = None;
+    for d in dirs {
+        let Ok(rd) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            let is_exe = p
+                .extension()
+                .map(|x| x.eq_ignore_ascii_case("exe"))
+                .unwrap_or(false);
+            if !is_exe {
+                continue;
+            }
+            let stem = p
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_lowercase())
+                .unwrap_or_default();
+            // 跳过明显的辅助程序
+            if stem.contains("unins")
+                || stem.contains("update")
+                || stem.contains("crash")
+                || stem.contains("setup")
+                || stem.contains("helper")
+            {
+                continue;
+            }
+            let size = e.metadata().map(|m| m.len()).unwrap_or(0);
+            // 名字与目录相关的 exe 强烈优先（加一个很大的基数）
+            let name_match = (!first_word.is_empty()
+                && (stem.contains(&first_word) || first_word.contains(&stem)))
+                || folder.contains(&stem);
+            let score = if name_match { size + (1 << 40) } else { size };
+            if best.as_ref().map(|(s, _)| score > *s).unwrap_or(true) {
+                best = Some((score, p));
+            }
+        }
+    }
+    best.map(|(_, p)| p.to_string_lossy().to_string())
+}
+
+/// 用 ExtractIconExW 按索引取图标。
+fn extract_icon_rgba(path: &str, index: i32) -> Option<(u32, u32, Vec<u8>)> {
+    use windows_sys::Win32::UI::Shell::ExtractIconExW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::DestroyIcon;
+
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    // 负索引在 DisplayIcon 里表示资源 ID，ExtractIconEx 不支持，退回 0
+    let idx = if index < 0 { 0 } else { index };
+    unsafe {
+        let mut large = std::ptr::null_mut();
+        let mut small = std::ptr::null_mut();
+        let n = ExtractIconExW(wide.as_ptr(), idx, &mut large, &mut small, 1);
+        if n == 0 || n == u32::MAX {
+            return None;
+        }
+        let hicon = if !large.is_null() { large } else { small };
+        let out = if hicon.is_null() {
+            None
+        } else {
+            hicon_to_rgba(hicon)
+        };
+        if !large.is_null() {
+            DestroyIcon(large);
+        }
+        if !small.is_null() {
+            DestroyIcon(small);
+        }
+        out
+    }
+}
+
+/// 用 SHGetFileInfoW 取 Shell 图标（处理 .ico / 默认关联 / exe 首图标等）。
+fn shell_icon_rgba(path: &str) -> Option<(u32, u32, Vec<u8>)> {
+    use windows_sys::Win32::UI::Shell::{SHGetFileInfoW, SHFILEINFOW};
+    use windows_sys::Win32::UI::WindowsAndMessaging::DestroyIcon;
+
+    const SHGFI_ICON: u32 = 0x0000_0100;
+    const SHGFI_LARGEICON: u32 = 0x0000_0000;
+
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    unsafe {
+        let mut fi: SHFILEINFOW = std::mem::zeroed();
+        let ok = SHGetFileInfoW(
+            wide.as_ptr(),
+            0,
+            &mut fi,
+            std::mem::size_of::<SHFILEINFOW>() as u32,
+            SHGFI_ICON | SHGFI_LARGEICON,
+        );
+        if ok == 0 || fi.hIcon.is_null() {
+            return None;
+        }
+        let out = hicon_to_rgba(fi.hIcon);
+        DestroyIcon(fi.hIcon);
+        out
+    }
+}
+
+/// HICON → (宽, 高, RGBA)。调用方负责销毁 HICON。
+unsafe fn hicon_to_rgba(
+    hicon: windows_sys::Win32::UI::WindowsAndMessaging::HICON,
+) -> Option<(u32, u32, Vec<u8>)> {
+    use windows_sys::Win32::Graphics::Gdi::{
+        CreateCompatibleDC, DeleteDC, DeleteObject, GetDIBits, GetObjectW, BITMAP, BITMAPINFO,
+        BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS,
+    };
+    use windows_sys::Win32::UI::WindowsAndMessaging::{GetIconInfo, ICONINFO};
+
+    let mut ii: ICONINFO = std::mem::zeroed();
+    if GetIconInfo(hicon, &mut ii) == 0 {
+        return None;
+    }
+
+    let mut bmp: BITMAP = std::mem::zeroed();
+    GetObjectW(
+        ii.hbmColor as _,
+        std::mem::size_of::<BITMAP>() as i32,
+        &mut bmp as *mut _ as *mut _,
+    );
+    let w = bmp.bmWidth.max(0) as u32;
+    let h = bmp.bmHeight.max(0) as u32;
+    let hdc = CreateCompatibleDC(std::ptr::null_mut());
+
+    let result = if w == 0 || h == 0 {
+        None
+    } else {
+        let mut bi: BITMAPINFO = std::mem::zeroed();
+        bi.bmiHeader = BITMAPINFOHEADER {
+            biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+            biWidth: w as i32,
+            biHeight: -(h as i32), // top-down
+            biPlanes: 1,
+            biBitCount: 32,
+            biCompression: BI_RGB as u32,
+            biSizeImage: 0,
+            biXPelsPerMeter: 0,
+            biYPelsPerMeter: 0,
+            biClrUsed: 0,
+            biClrImportant: 0,
+        };
+        let mut buf = vec![0u8; (w * h * 4) as usize];
+        let got = GetDIBits(
+            hdc,
+            ii.hbmColor as _,
+            0,
+            h,
+            buf.as_mut_ptr() as *mut _,
+            &mut bi,
+            DIB_RGB_COLORS,
+        );
+        if got == 0 {
+            None
+        } else {
+            let mut any_alpha = false;
+            for px in buf.chunks_exact_mut(4) {
+                px.swap(0, 2); // BGRA -> RGBA
+                if px[3] != 0 {
+                    any_alpha = true;
+                }
+            }
+            if !any_alpha {
+                apply_mask_alpha(hdc, ii.hbmMask as _, w, h, &mut buf);
+            }
+            Some((w, h, buf))
+        }
+    };
+
+    if !hdc.is_null() {
+        DeleteDC(hdc);
+    }
+    if !ii.hbmColor.is_null() {
+        DeleteObject(ii.hbmColor as _);
+    }
+    if !ii.hbmMask.is_null() {
+        DeleteObject(ii.hbmMask as _);
+    }
+    result
+}
+
+/// 从 1bpp 掩码位图导出 alpha：掩码位为 1 处透明、为 0 处不透明。
+unsafe fn apply_mask_alpha(
+    hdc: windows_sys::Win32::Graphics::Gdi::HDC,
+    hmask: windows_sys::Win32::Graphics::Gdi::HBITMAP,
+    w: u32,
+    h: u32,
+    rgba: &mut [u8],
+) {
+    use windows_sys::Win32::Graphics::Gdi::{
+        GetDIBits, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS,
+    };
+    let row_bytes = (((w + 31) / 32) * 4) as usize;
+    let mut mask = vec![0u8; row_bytes * h as usize];
+    let mut bi: BITMAPINFO = std::mem::zeroed();
+    bi.bmiHeader = BITMAPINFOHEADER {
+        biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+        biWidth: w as i32,
+        biHeight: -(h as i32),
+        biPlanes: 1,
+        biBitCount: 1,
+        biCompression: BI_RGB as u32,
+        biSizeImage: 0,
+        biXPelsPerMeter: 0,
+        biYPelsPerMeter: 0,
+        biClrUsed: 0,
+        biClrImportant: 0,
+    };
+    let got = GetDIBits(
+        hdc,
+        hmask,
+        0,
+        h,
+        mask.as_mut_ptr() as *mut _,
+        &mut bi,
+        DIB_RGB_COLORS,
+    );
+    if got == 0 {
+        for px in rgba.chunks_exact_mut(4) {
+            px[3] = 255;
+        }
+        return;
+    }
+    for y in 0..h as usize {
+        for x in 0..w as usize {
+            let bit = (mask[y * row_bytes + (x / 8)] >> (7 - (x % 8))) & 1;
+            rgba[(y * w as usize + x) * 4 + 3] = if bit == 0 { 255 } else { 0 };
+        }
+    }
+}
+
+/// RGBA 像素编码为 PNG 字节。
+fn encode_png(w: u32, h: u32, rgba: &[u8]) -> Option<Vec<u8>> {
+    let mut out = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(Cursor::new(&mut out), w, h);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().ok()?;
+        writer.write_image_data(rgba).ok()?;
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_display_icon_handles_index_and_quotes() {
+        assert_eq!(
+            parse_display_icon("\"C:\\App\\a.exe\",0"),
+            Some(("C:\\App\\a.exe".to_string(), 0))
+        );
+        assert_eq!(
+            parse_display_icon("C:\\App\\a.exe,3"),
+            Some(("C:\\App\\a.exe".to_string(), 3))
+        );
+        assert_eq!(
+            parse_display_icon("\"C:\\App\\a.ico\""),
+            Some(("C:\\App\\a.ico".to_string(), 0))
+        );
+        assert_eq!(parse_display_icon("  "), None);
+    }
+}

--- a/src-tauri/src/icon.rs
+++ b/src-tauri/src/icon.rs
@@ -14,6 +14,10 @@ fn try_icon_file(path: &str, idx: i32) -> Option<(u32, u32, Vec<u8>)> {
     if p.is_empty() || !Path::new(&p).exists() {
         return None;
     }
+    // 首选 PrivateExtractIcons：按固定尺寸(64)栅格化，对现代/大尺寸/PNG压缩图标最稳（如微信 Weixin.exe）
+    if let Some(r) = extract_via_private(&p, idx, 64) {
+        return Some(r);
+    }
     if let Some(r) = extract_icon_rgba(&p, idx) {
         return Some(r);
     }
@@ -317,6 +321,39 @@ fn main_exe_in(dir: &str) -> Option<String> {
         }
     }
     best.map(|(_, p)| p.to_string_lossy().to_string())
+}
+
+/// user32 导出的 PrivateExtractIconsW（windows-sys 未在 Shell 模块暴露，自行声明）。
+#[link(name = "user32")]
+extern "system" {
+    fn PrivateExtractIconsW(
+        szfilename: *const u16,
+        niconindex: i32,
+        cxicon: i32,
+        cyicon: i32,
+        phicon: *mut *mut core::ffi::c_void,
+        piconid: *mut u32,
+        nicons: u32,
+        flags: u32,
+    ) -> u32;
+}
+
+/// 用 PrivateExtractIconsW 按指定像素尺寸栅格化取图标（对现代/PNG压缩/大尺寸图标最可靠）。
+fn extract_via_private(path: &str, index: i32, size: i32) -> Option<(u32, u32, Vec<u8>)> {
+    use windows_sys::Win32::UI::WindowsAndMessaging::DestroyIcon;
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    let idx = if index < 0 { 0 } else { index };
+    unsafe {
+        let mut hicon: *mut core::ffi::c_void = std::ptr::null_mut();
+        let mut id: u32 = 0;
+        let n = PrivateExtractIconsW(wide.as_ptr(), idx, size, size, &mut hicon, &mut id, 1, 0);
+        if n == 0 || n == u32::MAX || hicon.is_null() {
+            return None;
+        }
+        let out = hicon_to_rgba(hicon as _);
+        DestroyIcon(hicon as _);
+        out
+    }
 }
 
 /// 用 ExtractIconExW 按索引取图标。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod cleanup;
 mod collector;
+mod icon;
 pub mod knowledge;
 mod memory;
 pub mod mft_scan;
@@ -9,6 +10,7 @@ mod startup;
 mod stats;
 pub mod svc;
 mod svc_client;
+mod uninstall;
 
 use cache::ScanCache;
 use cleanup::{CleanupReport, CleanupScan, DeepAnalyzeReport, DeepCleanReport};
@@ -16,6 +18,7 @@ use memory::MemoryReport;
 use scan::{DriveInfo, TreeNode};
 use startup::StartupItem;
 use stats::CleanupStats;
+use uninstall::{InstalledApp, LeftoverInput, LeftoverItem, RemoveResult};
 
 /// 枚举系统盘符及容量。
 #[tauri::command]
@@ -158,6 +161,60 @@ async fn repair_scan_service() -> Result<(), String> {
         .map_err(|e| format!("修复任务失败：{}", e))?
 }
 
+/// 枚举已安装的桌面软件（注册表 Uninstall 键）。
+#[tauri::command]
+async fn list_installed_apps() -> Result<Vec<InstalledApp>, String> {
+    tauri::async_runtime::spawn_blocking(uninstall::list_installed)
+        .await
+        .map_err(|e| format!("枚举已装软件失败：{}", e))
+}
+
+/// 调用软件自带卸载器（向导模式），阻塞等待其结束，返回退出码。
+#[tauri::command]
+async fn run_app_uninstaller(id: String) -> Result<i32, String> {
+    tauri::async_runtime::spawn_blocking(move || uninstall::run_uninstaller(&id))
+        .await
+        .map_err(|e| format!("卸载任务失败：{}", e))?
+}
+
+/// 扫描残留（文件夹 + 注册表）；卸载后原注册表键已删，按前端缓存字段扫描。
+#[tauri::command]
+async fn scan_app_leftovers(
+    name: String,
+    publisher: String,
+    install_location: String,
+) -> Result<Vec<LeftoverItem>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        uninstall::scan_leftovers(&name, &publisher, &install_location)
+    })
+    .await
+    .map_err(|e| format!("扫描残留失败：{}", e))
+}
+
+/// 删除勾选的残留项（文件夹进回收站、注册表先导出 .reg 备份后删）。
+#[tauri::command]
+async fn remove_app_leftovers(items: Vec<LeftoverInput>) -> Result<Vec<RemoveResult>, String> {
+    tauri::async_runtime::spawn_blocking(move || uninstall::remove_leftovers(items))
+        .await
+        .map_err(|e| format!("删除残留失败：{}", e))
+}
+
+/// 提取应用图标（按需、逐个）：优先 DisplayIcon，取不到逐级退回安装目录/卸载器主 exe。返回 PNG base64 data URI。
+#[tauri::command]
+async fn app_icon(
+    icon_path: String,
+    install_location: String,
+    uninstall_string: String,
+    name: String,
+) -> Option<String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        icon::icon_data_uri(&icon_path, &install_location, &uninstall_string, &name)
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -179,7 +236,12 @@ pub fn run() {
             open_recycle_bin,
             collect_rules,
             scan_service_available,
-            repair_scan_service
+            repair_scan_service,
+            list_installed_apps,
+            run_app_uninstaller,
+            scan_app_leftovers,
+            remove_app_leftovers,
+            app_icon
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -171,6 +171,14 @@ async fn list_installed_apps() -> Result<Vec<InstalledApp>, String> {
         .map_err(|e| format!("枚举已装软件失败：{}", e))
 }
 
+/// 枚举 UWP/商店应用（较慢，前端在 Win32 列表渲染后异步追加，保证“打开即显示”）。
+#[tauri::command]
+async fn list_uwp_apps() -> Result<Vec<InstalledApp>, String> {
+    tauri::async_runtime::spawn_blocking(uninstall::list_uwp)
+        .await
+        .map_err(|e| format!("枚举商店应用失败：{}", e))
+}
+
 /// 调用软件自带卸载器（向导模式），阻塞等待其结束，返回退出码。
 #[tauri::command]
 async fn run_app_uninstaller(id: String) -> Result<i32, String> {
@@ -260,6 +268,7 @@ pub fn run() {
             scan_service_available,
             repair_scan_service,
             list_installed_apps,
+            list_uwp_apps,
             run_app_uninstaller,
             scan_app_leftovers,
             remove_app_leftovers,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod cache;
 mod cleanup;
 mod collector;
+mod force_delete;
 mod icon;
 pub mod knowledge;
 mod memory;
@@ -14,6 +15,7 @@ mod uninstall;
 
 use cache::ScanCache;
 use cleanup::{CleanupReport, CleanupScan, DeepAnalyzeReport, DeepCleanReport};
+use force_delete::LockingProcess;
 use memory::MemoryReport;
 use scan::{DriveInfo, TreeNode};
 use startup::StartupItem;
@@ -215,6 +217,26 @@ async fn app_icon(
     .flatten()
 }
 
+/// 查找占用指定文件/文件夹的进程（Restart Manager，资源监视器同款）。
+#[tauri::command]
+async fn find_file_lockers(path: String) -> Vec<LockingProcess> {
+    tauri::async_runtime::spawn_blocking(move || force_delete::find_lockers(&path))
+        .await
+        .unwrap_or_default()
+}
+
+/// 强力删除：先尝试关句柄解锁，仍占用则结束整个占用应用后删除（to_recycle=true 进回收站可恢复）。
+#[tauri::command]
+async fn force_delete_path(
+    path: String,
+    pids: Vec<u32>,
+    to_recycle: bool,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || force_delete::force_delete(&path, pids, to_recycle))
+        .await
+        .map_err(|e| format!("强力删除任务失败：{}", e))?
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -241,7 +263,9 @@ pub fn run() {
             run_app_uninstaller,
             scan_app_leftovers,
             remove_app_leftovers,
-            app_icon
+            app_icon,
+            find_file_lockers,
+            force_delete_path
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/uninstall.rs
+++ b/src-tauri/src/uninstall.rs
@@ -1,0 +1,958 @@
+//! 软件卸载引擎（类 Geek Uninstaller）：枚举已装软件、调用其原生卸载器、
+//! 扫描并清理卸载后的残留（文件夹 + 注册表项）。
+//!
+//! 安全原则与全项目一致：前端只传回软件 id 与「后端扫出的」残留路径，
+//! 实际操作前后端都会重新解析校验；文件删入回收站可恢复，注册表删除前先导出 .reg 备份。
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ};
+use winreg::RegKey;
+
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// 三个标准卸载注册表位置（64 位机器软件分散在这三处）。
+/// 元组：(hive, 子路径, hive 文本标签用于 reg export)
+const UNINSTALL_HIVES: [(winreg::HKEY, &str, &str); 3] = [
+    (
+        HKEY_LOCAL_MACHINE,
+        r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKLM",
+    ),
+    (
+        HKEY_LOCAL_MACHINE,
+        r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKLM",
+    ),
+    (
+        HKEY_CURRENT_USER,
+        r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        "HKCU",
+    ),
+];
+
+/// 一个已安装软件（序列化给前端）。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledApp {
+    /// 注册表子键名（如 GUID 或应用名），用于后端重新定位
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub publisher: String,
+    pub install_location: String,
+    /// 图标来源（DisplayIcon，去掉资源索引后缀），前端可选用
+    pub icon_path: String,
+    /// EstimatedSize 换算的字节数（注册表以 KB 记，可能为 0）
+    pub size: u64,
+    /// 是否具备静默卸载串（前端仅作提示，本版一律走向导）
+    pub has_quiet: bool,
+    /// UninstallString（图标兑底时用于定位卸载器/主程序目录）
+    pub uninstall_string: String,
+}
+
+/// 卸载后扫描出的单个残留项。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeftoverItem {
+    /// "dir" 文件夹 | "reg" 注册表项
+    pub kind: String,
+    /// 文件夹绝对路径，或注册表全路径（如 HKCU\Software\Foo）
+    pub path: String,
+    /// 文件夹字节数；注册表项为 0
+    pub size: u64,
+    /// "high" 高置信度（安装目录残留/名称精确匹配）| "low" 需谨慎
+    pub confidence: String,
+}
+
+/// 前端回传的待删残留（与 LeftoverItem 的 kind/path 对应）。
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LeftoverInput {
+    pub kind: String,
+    pub path: String,
+}
+
+/// 单项残留删除结果。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoveResult {
+    pub path: String,
+    pub ok: bool,
+    pub error: Option<String>,
+}
+
+// ---------- 工具 ----------
+
+fn env_path(var: &str) -> Option<PathBuf> {
+    std::env::var_os(var).map(PathBuf::from)
+}
+
+/// 目录递归字节数（残留项通常不大，直接走 std 遍历即可）。
+fn dir_size(path: &Path) -> u64 {
+    let mut total = 0u64;
+    let Ok(read) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    for entry in read.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_dir() {
+            total += dir_size(&entry.path());
+        } else if let Ok(m) = entry.metadata() {
+            total += m.len();
+        }
+    }
+    total
+}
+
+fn norm(s: &str) -> String {
+    s.trim().to_lowercase()
+}
+
+/// 过于宽泛、匹配到会误伤共享目录的名字（厂商大类/系统词）。
+fn is_generic(name: &str) -> bool {
+    matches!(
+        norm(name).as_str(),
+        "" | "microsoft"
+            | "windows"
+            | "common files"
+            | "common"
+            | "google"
+            | "intel"
+            | "nvidia"
+            | "amd"
+            | "realtek"
+            | "temp"
+            | "cache"
+            | "data"
+    )
+}
+
+/// 去掉软件名尾部的版本号（如 "ocs desktop 2.8.5" -> "ocs desktop"），用于匹配不带版本的注册表键。
+fn strip_version_suffix(s: &str) -> String {
+    let mut parts: Vec<&str> = s.split_whitespace().collect();
+    while let Some(last) = parts.last() {
+        let is_ver = last.chars().all(|c| c.is_ascii_digit() || c == '.' || c == 'v')
+            && last.chars().any(|c| c.is_ascii_digit());
+        if is_ver && parts.len() > 1 {
+            parts.pop();
+        } else {
+            break;
+        }
+    }
+    parts.join(" ")
+}
+
+/// 发行商标准化：去掉 "llc/inc/ltd/corporation/gmbh/co" 等后缀与标点，得到用于匹配注册表文件夹的核心名。
+/// 如 "Google LLC" -> "google"，"JetBrains s.r.o." -> "jetbrains"。
+fn norm_publisher(pubname: &str) -> String {
+    let mut s = norm(pubname);
+    for junk in [",", ".", "(", ")"] {
+        s = s.replace(junk, " ");
+    }
+    let stop = [
+        "llc", "inc", "ltd", "limited", "corporation", "corp", "co", "company", "gmbh", "srl",
+        "sro", "ab", "bv", "kg", "llp", "pte", "technologies", "technology", "software",
+    ];
+    let kept: Vec<&str> = s.split_whitespace().filter(|w| !stop.contains(w)).collect();
+    kept.join(" ")
+}
+
+/// 注册表子键名与软件名的匹配判定（cand 已小写）。宁缺勿误，不命中返回 None。
+fn reg_name_match(cand: &str, name_l: &str, name_core: &str) -> Option<&'static str> {
+    if is_generic(cand) {
+        return None;
+    }
+    if cand == name_l {
+        return Some("high");
+    }
+    if !name_core.is_empty() && name_core.len() >= 4 && cand == name_core {
+        return Some("high");
+    }
+    // 软件名以该键名开头（键名足够长）：如 "ocs desktop 2.8.5" 匹配键名 "ocs desktop"
+    if cand.len() >= 5 && name_l.starts_with(cand) {
+        return Some("high");
+    }
+    None
+}
+
+// ---------- 枚举已装软件 ----------
+
+/// 一条注册表卸载项里执行卸载所需的原始字段（内部用，不序列化）。
+struct AppRaw {
+    uninstall_string: String,
+    quiet_string: String,
+    msi: bool,
+}
+
+/// 枚举全部已安装的桌面软件，按名称排序、同名去重。
+pub fn list_installed() -> Vec<InstalledApp> {
+    let mut apps: Vec<InstalledApp> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for (idx, (hive, path, _tag)) in UNINSTALL_HIVES.iter().enumerate() {
+        let Ok(root) = RegKey::predef(*hive).open_subkey_with_flags(path, KEY_READ) else {
+            continue;
+        };
+        for sub in root.enum_keys().flatten() {
+            let Ok(key) = root.open_subkey_with_flags(&sub, KEY_READ) else {
+                continue;
+            };
+            let name: String = match key.get_value("DisplayName") {
+                Ok(n) => {
+                    let n: String = n;
+                    n.trim().to_string()
+                }
+                Err(_) => continue,
+            };
+            if name.is_empty() {
+                continue;
+            }
+            if key.get_value::<u32, _>("SystemComponent").unwrap_or(0) == 1 {
+                continue;
+            }
+            if key.get_value::<String, _>("ParentKeyName").is_ok() {
+                continue;
+            }
+            let release_type: String = key.get_value("ReleaseType").unwrap_or_default();
+            if release_type.contains("Update") || release_type.contains("Hotfix") {
+                continue;
+            }
+            let uninstall: String = key.get_value("UninstallString").unwrap_or_default();
+            let quiet: String = key.get_value("QuietUninstallString").unwrap_or_default();
+            if uninstall.trim().is_empty() && quiet.trim().is_empty() {
+                continue;
+            }
+
+            let version: String = key.get_value("DisplayVersion").unwrap_or_default();
+            let publisher: String = key.get_value("Publisher").unwrap_or_default();
+            let install_location: String = key.get_value("InstallLocation").unwrap_or_default();
+            let icon: String = key.get_value("DisplayIcon").unwrap_or_default();
+            let est_kb = key.get_value::<u32, _>("EstimatedSize").unwrap_or(0);
+
+            // 去重键：名称 + 版本（WOW6432Node 与主键常重复登记同一软件）
+            let dedup = format!("{}\u{1}{}", norm(&name), norm(&version));
+            if !seen.insert(dedup) {
+                continue;
+            }
+
+            apps.push(InstalledApp {
+                // id 编码 hive 序号，保证全局唯一（同一子键名可能出现在多个 hive）
+                id: format!("{}|{}", idx, sub),
+                name,
+                version: version.trim().to_string(),
+                publisher: publisher.trim().to_string(),
+                install_location: install_location.trim().to_string(),
+                icon_path: icon.trim().to_string(),
+                size: (est_kb as u64) * 1024,
+                has_quiet: !quiet.trim().is_empty(),
+                uninstall_string: uninstall.trim().to_string(),
+            });
+        }
+    }
+
+    apps.extend(list_uwp());
+    apps.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    apps
+}
+
+/// 枚举可卸载的 UWP/商店应用（Get-AppxPackage），解析友好名与包内 logo。
+/// 过滤框架包/系统包/不可卸载项；DisplayName 为 ms-resource 时退回包名末段。
+fn list_uwp() -> Vec<InstalledApp> {
+    use std::os::windows::process::CommandExt;
+    let script = r#"[Console]::OutputEncoding=[System.Text.Encoding]::UTF8
+$ErrorActionPreference='SilentlyContinue'
+$apps = Get-AppxPackage | Where-Object { -not $_.IsFramework -and -not $_.NonRemovable -and $_.SignatureKind -ne 'System' }
+$list = foreach ($p in $apps) {
+  $dn=''; $logo=''; $pub=''
+  try {
+    $m = Get-AppxPackageManifest -Package $p.PackageFullName
+    $dn = [string]$m.Package.Properties.DisplayName
+    $pub = [string]$m.Package.Properties.PublisherDisplayName
+    $logo = [string]$m.Package.Properties.Logo
+    $vdn = [string]$m.Package.Applications.Application.VisualElements.DisplayName
+    if (($dn -eq '' -or $dn -like 'ms-resource:*') -and $vdn -and $vdn -notlike 'ms-resource:*') { $dn = $vdn }
+  } catch {}
+  if (-not $dn -or $dn -like 'ms-resource:*') { $dn = ($p.Name -split '\.')[-1] }
+  $logoPath=''
+  if ($p.InstallLocation -and $logo) {
+    $ldir = Join-Path $p.InstallLocation (Split-Path $logo -Parent)
+    $lbase = [System.IO.Path]::GetFileNameWithoutExtension($logo)
+    $c = Get-ChildItem -LiteralPath $ldir -Filter "$lbase*.png" | Sort-Object Length -Descending | Select-Object -First 1
+    if ($c) { $logoPath = $c.FullName }
+  }
+  if (-not $logoPath -and $p.InstallLocation) {
+    $c = Get-ChildItem -LiteralPath $p.InstallLocation -Recurse -Depth 2 -Filter '*Square44x44Logo*.png' | Sort-Object Length -Descending | Select-Object -First 1
+    if ($c) { $logoPath = $c.FullName }
+  }
+  [PSCustomObject]@{ id=$p.PackageFullName; name=$dn; publisher=$pub; install=$p.InstallLocation; logo=$logoPath }
+}
+$list | ConvertTo-Json -Compress"#;
+
+    let output = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", script])
+        .creation_flags(CREATE_NO_WINDOW)
+        .output();
+    let Ok(out) = output else {
+        return Vec::new();
+    };
+    let text = String::from_utf8_lossy(&out.stdout);
+    let text = text.trim();
+    if text.is_empty() {
+        return Vec::new();
+    }
+    // ConvertTo-Json：单个对象为 {}，多个为 []
+    let val: serde_json::Value = match serde_json::from_str(text) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let arr = match val {
+        serde_json::Value::Array(a) => a,
+        v @ serde_json::Value::Object(_) => vec![v],
+        _ => return Vec::new(),
+    };
+    let mut result = Vec::new();
+    for item in arr {
+        let get = |k: &str| {
+            item.get(k)
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string()
+        };
+        let pfn = get("id");
+        if pfn.is_empty() {
+            continue;
+        }
+        let name = get("name");
+        // 从 PackageFullName 抽版本：Name_Version_arch__hash
+        let version = pfn.split('_').nth(1).unwrap_or("").to_string();
+        result.push(InstalledApp {
+            id: format!("uwp|{}", pfn),
+            name: if name.is_empty() { pfn.clone() } else { name },
+            version,
+            publisher: get("publisher"),
+            install_location: get("install"),
+            icon_path: get("logo"),
+            size: 0,
+            has_quiet: false,
+            uninstall_string: String::new(),
+        });
+    }
+    result
+}
+
+/// 按 id 定位软件，返回执行卸载所需字段。
+/// id 形如 "1|{GUID}"：剩 hive 序号 + 子键名；旧格式（无 "|"）则遗历三个 hive 兼容。
+fn find_app(id: &str) -> Option<AppRaw> {
+    let read = |hive: winreg::HKEY, path: &str, sub: &str| -> Option<AppRaw> {
+        let root = RegKey::predef(hive).open_subkey_with_flags(path, KEY_READ).ok()?;
+        let key = root.open_subkey_with_flags(sub, KEY_READ).ok()?;
+        let name: String = key.get_value("DisplayName").unwrap_or_default();
+        if name.trim().is_empty() {
+            return None;
+        }
+        Some(AppRaw {
+            uninstall_string: key.get_value("UninstallString").unwrap_or_default(),
+            quiet_string: key.get_value("QuietUninstallString").unwrap_or_default(),
+            msi: key.get_value::<u32, _>("WindowsInstaller").unwrap_or(0) == 1,
+        })
+    };
+
+    // 新格式：hive 序号 | 子键名，直接定位
+    if let Some((idx_str, sub)) = id.split_once('|') {
+        if let Ok(idx) = idx_str.parse::<usize>() {
+            if let Some((hive, path, _)) = UNINSTALL_HIVES.get(idx) {
+                return read(*hive, path, sub);
+            }
+        }
+    }
+    // 旧格式兜底：按子键名遍历三个 hive
+    for (hive, path, _tag) in UNINSTALL_HIVES {
+        if let Some(app) = read(hive, path, id) {
+            return Some(app);
+        }
+    }
+    None
+}
+
+/// 把卸载命令行拆成 (可执行文件, 参数串)。支持引号包裹的带空格路径。
+fn split_command(s: &str) -> (String, String) {
+    let s = s.trim();
+    if let Some(rest) = s.strip_prefix('"') {
+        if let Some(end) = rest.find('"') {
+            let exe = rest[..end].to_string();
+            let args = rest[end + 1..].trim_start().to_string();
+            return (exe, args);
+        }
+    }
+    match s.find(' ') {
+        Some(i) => (s[..i].to_string(), s[i + 1..].trim_start().to_string()),
+        None => (s.to_string(), String::new()),
+    }
+}
+
+// ---------- 执行原生卸载 ----------
+
+/// 卸载 UWP/商店应用（Remove-AppxPackage，每用户无需提权）。
+fn remove_appx(pfn: &str) -> Result<i32, String> {
+    use std::os::windows::process::CommandExt;
+    // 仅允许合法 PackageFullName 字符，防注入
+    if pfn.is_empty()
+        || !pfn
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+    {
+        return Err("非法的应用包名。".to_string());
+    }
+    let ps = format!("Remove-AppxPackage -Package '{}'", pfn);
+    let status = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &ps])
+        .creation_flags(CREATE_NO_WINDOW)
+        .status()
+        .map_err(|e| format!("卸载商店应用失败：{}", e))?;
+    Ok(status.code().unwrap_or(-1))
+}
+
+/// 调用软件自带卸载器（向导模式），阻塞等待其结束。返回卸载器退出码。
+/// 手动拆解可执行文件与参数、用 raw_arg 原样传递，避开 `cmd /c` 对引号路径的错误拆分。
+pub fn run_uninstaller(id: &str) -> Result<i32, String> {
+    use std::os::windows::process::CommandExt;
+
+    // UWP/商店应用：走 Remove-AppxPackage
+    if let Some(pfn) = id.strip_prefix("uwp|") {
+        return remove_appx(pfn);
+    }
+
+    let app = find_app(id).ok_or("找不到该软件的卸载信息（可能已被卸载）")?;
+    let mut cmdline = app.uninstall_string.trim().to_string();
+    if cmdline.is_empty() {
+        cmdline = app.quiet_string.trim().to_string();
+    }
+    if cmdline.is_empty() {
+        return Err("该软件未提供卸载命令。".to_string());
+    }
+    // MSI 型：UninstallString 常是 MsiExec /I{GUID}，改成 /X 才是卸载
+    if app.msi {
+        cmdline = cmdline.replacen("/I", "/X", 1).replacen("/i", "/x", 1);
+    }
+
+    let (exe, args) = split_command(&cmdline);
+    let mut cmd = std::process::Command::new(&exe);
+    if !args.is_empty() {
+        cmd.raw_arg(&args);
+    }
+    let status = cmd
+        .status()
+        .map_err(|e| format!("启动卸载程序失败：{}", e))?;
+    Ok(status.code().unwrap_or(-1))
+}
+
+// ---------- 扫描残留 ----------
+
+/// 卸载后扫描残留：安装目录残余 + 常见数据目录下的同名目录 + 相关注册表项。
+/// 保守收录（宁漏勿误）：只认安装目录与「名称精确匹配」的目录，厂商级泛目录一律跳过。
+///
+/// 卸载器执行后软件的原注册表键通常已被删除，因此按前端缓存的字段（而非 id）扫描。
+pub fn scan_leftovers(name: &str, publisher: &str, install_location: &str) -> Vec<LeftoverItem> {
+    let mut out: Vec<LeftoverItem> = Vec::new();
+    let mut seen_dirs: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let name_l = norm(name);
+
+    // 1) 安装目录本身仍残留 —— 高置信度
+    if !install_location.is_empty() {
+        let p = PathBuf::from(install_location);
+        if p.is_dir() && seen_dirs.insert(norm(install_location)) {
+            out.push(LeftoverItem {
+                kind: "dir".into(),
+                path: install_location.to_string(),
+                size: dir_size(&p),
+                confidence: "high".into(),
+            });
+        }
+    }
+
+    // 2) 常见数据目录下「目录名精确等于软件名」的残留
+    let roots: Vec<PathBuf> = [
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "ProgramW6432",
+        "LOCALAPPDATA",
+        "APPDATA",
+        "ProgramData",
+    ]
+    .iter()
+    .filter_map(|v| env_path(v))
+    .collect();
+
+    for root in &roots {
+        let Ok(read) = std::fs::read_dir(root) else {
+            continue;
+        };
+        for entry in read.flatten() {
+            let Ok(ft) = entry.file_type() else { continue };
+            if !ft.is_dir() {
+                continue;
+            }
+            let dir_name = entry.file_name().to_string_lossy().to_string();
+            let dl = norm(&dir_name);
+            if is_generic(&dl) {
+                continue;
+            }
+            let path = entry.path();
+            let key = norm(&path.to_string_lossy());
+            if seen_dirs.contains(&key) {
+                continue;
+            }
+            // 精确匹配软件名（高）；等于发行商且发行商非泛词（低）
+            let confidence = if dl == name_l {
+                "high"
+            } else if !publisher.is_empty() && dl == norm(publisher) && !is_generic(publisher) {
+                "low"
+            } else {
+                continue;
+            };
+            seen_dirs.insert(key);
+            out.push(LeftoverItem {
+                kind: "dir".into(),
+                path: path.to_string_lossy().to_string(),
+                size: dir_size(&path),
+                confidence: confidence.into(),
+            });
+        }
+    }
+
+    // 3) 注册表残留：直接命中 Software\<产品>、嵌套 Software\<发行商>\<产品>、以及残留的卸载登记键
+    let reg_targets: [(winreg::HKEY, &str, &str); 4] = [
+        (HKEY_CURRENT_USER, "HKCU", r"Software"),
+        (HKEY_LOCAL_MACHINE, "HKLM", r"SOFTWARE"),
+        (HKEY_LOCAL_MACHINE, "HKLM", r"SOFTWARE\WOW6432Node"),
+        (HKEY_CURRENT_USER, "HKCU", r"Software\WOW6432Node"),
+    ];
+    let name_core = strip_version_suffix(&name_l);
+    let pub_l = norm(publisher);
+    let pub_core = norm_publisher(publisher);
+    let mut seen_reg: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut push_reg = |out: &mut Vec<LeftoverItem>, full: String, conf: &str| {
+        if seen_reg.insert(norm(&full)) {
+            out.push(LeftoverItem {
+                kind: "reg".into(),
+                path: full,
+                size: 0,
+                confidence: conf.into(),
+            });
+        }
+    };
+
+    for (hive, tag, base) in reg_targets {
+        let Ok(root) = RegKey::predef(hive).open_subkey_with_flags(base, KEY_READ) else {
+            continue;
+        };
+        for sub in root.enum_keys().flatten() {
+            let sl = norm(&sub);
+            if is_generic(&sl) {
+                continue;
+            }
+            // 直接命中 Software\<产品>
+            if let Some(conf) = reg_name_match(&sl, &name_l, &name_core) {
+                push_reg(&mut out, format!("{}\\{}\\{}", tag, base, sub), conf);
+                continue;
+            }
+            // 嵌套：Software\<发行商>\<产品>——命中发行商文件夹后，只挑其中与软件名匹配的子键
+            // 发行商文件夹名常与 DisplayName 中的发行商不一致（如 "Google LLC" vs 文件夹 "Google"），故用标准化名匹配
+            let is_pub_folder =
+                (sl == pub_l || (!pub_core.is_empty() && sl == pub_core)) && !is_generic(&sl);
+            if is_pub_folder {
+                if let Ok(pubkey) = root.open_subkey_with_flags(&sub, KEY_READ) {
+                    for q in pubkey.enum_keys().flatten() {
+                        let ql = norm(&q);
+                        if reg_name_match(&ql, &name_l, &name_core).is_some() {
+                            push_reg(
+                                &mut out,
+                                format!("{}\\{}\\{}\\{}", tag, base, sub, q),
+                                "high",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 3b) 残留的卸载登记键：卸载器有时不清自己的 Uninstall 键，按 DisplayName 匹配收回
+    for (hive, path, tag) in UNINSTALL_HIVES {
+        let Ok(root) = RegKey::predef(hive).open_subkey_with_flags(path, KEY_READ) else {
+            continue;
+        };
+        for sub in root.enum_keys().flatten() {
+            let Ok(k) = root.open_subkey_with_flags(&sub, KEY_READ) else {
+                continue;
+            };
+            let dn: String = k.get_value("DisplayName").unwrap_or_default();
+            if !dn.trim().is_empty() && norm(dn.trim()) == name_l {
+                push_reg(&mut out, format!("{}\\{}\\{}", tag, path, sub), "high");
+            }
+        }
+    }
+
+    // 3c) App Paths：按安装目录前缀精确匹配（默认值为 exe 全路径，在安装目录下即属于本软件）
+    if !install_location.trim().is_empty() {
+        let inst = norm(install_location.trim());
+        let app_paths: [(winreg::HKEY, &str, &str); 3] = [
+            (HKEY_LOCAL_MACHINE, "HKLM", r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"),
+            (
+                HKEY_LOCAL_MACHINE,
+                "HKLM",
+                r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\App Paths",
+            ),
+            (HKEY_CURRENT_USER, "HKCU", r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths"),
+        ];
+        for (hive, tag, base) in app_paths {
+            let Ok(root) = RegKey::predef(hive).open_subkey_with_flags(base, KEY_READ) else {
+                continue;
+            };
+            for sub in root.enum_keys().flatten() {
+                let Ok(k) = root.open_subkey_with_flags(&sub, KEY_READ) else {
+                    continue;
+                };
+                let def: String = k.get_value("").unwrap_or_default();
+                let def_n = norm(def.trim().trim_matches('"'));
+                if !def_n.is_empty() && def_n.starts_with(&inst) {
+                    push_reg(&mut out, format!("{}\\{}\\{}", tag, base, sub), "high");
+                }
+            }
+        }
+    }
+
+    out
+}
+
+// ---------- 删除残留 ----------
+
+/// 把指定文件夹删入回收站（可恢复）。path 必须是已存在的绝对目录。
+fn send_dir_to_recycle(path: &str) -> Result<(), String> {
+    use windows_sys::Win32::UI::Shell::{SHFileOperationW, SHFILEOPSTRUCTW};
+
+    // wFunc / fFlags 常量（手写以避免 features 命名差异）
+    const FO_DELETE: u32 = 0x0003;
+    const FOF_SILENT: u16 = 0x0004;
+    const FOF_NOCONFIRMATION: u16 = 0x0010;
+    const FOF_ALLOWUNDO: u16 = 0x0040;
+    const FOF_NOERRORUI: u16 = 0x0400;
+
+    // pFrom 需以双 null 结尾
+    let mut from: Vec<u16> = path.encode_utf16().collect();
+    from.push(0);
+    from.push(0);
+
+    let mut op = SHFILEOPSTRUCTW {
+        hwnd: std::ptr::null_mut(),
+        wFunc: FO_DELETE,
+        pFrom: from.as_ptr(),
+        pTo: std::ptr::null(),
+        fFlags: FOF_ALLOWUNDO | FOF_NOCONFIRMATION | FOF_SILENT | FOF_NOERRORUI,
+        fAnyOperationsAborted: 0,
+        hNameMappings: std::ptr::null_mut(),
+        lpszProgressTitle: std::ptr::null(),
+    };
+    let ret = unsafe { SHFileOperationW(&mut op) };
+    if ret == 0 && op.fAnyOperationsAborted == 0 {
+        Ok(())
+    } else {
+        Err(format!("移入回收站失败 (code={})", ret))
+    }
+}
+
+/// reg export 备份目录：%LOCALAPPDATA%\DiskButler\reg-backup\
+fn reg_backup_dir() -> Option<PathBuf> {
+    let dir = env_path("LOCALAPPDATA")?.join("DiskButler").join("reg-backup");
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir)
+}
+
+/// 把注册表全路径（HKCU\... / HKLM\...）拆成 (hive, 子路径)。
+fn split_reg(full: &str) -> Option<(winreg::HKEY, String)> {
+    let (tag, rest) = full.split_once('\\')?;
+    let hive = match tag.to_uppercase().as_str() {
+        "HKCU" | "HKEY_CURRENT_USER" => HKEY_CURRENT_USER,
+        "HKLM" | "HKEY_LOCAL_MACHINE" => HKEY_LOCAL_MACHINE,
+        _ => return None,
+    };
+    Some((hive, rest.to_string()))
+}
+
+/// 校验注册表目标只在 Software 分支（防误删系统关键键），返回 (hive, 子路径)。
+fn ensure_software_branch(full: &str) -> Result<(winreg::HKEY, String), String> {
+    let (hive, subpath) = split_reg(full).ok_or("注册表路径格式无法识别")?;
+    if !subpath.to_uppercase().starts_with("SOFTWARE") {
+        return Err("出于安全，只允许清理 Software 分支下的残留项。".to_string());
+    }
+    Ok((hive, subpath))
+}
+
+/// reg export 导出 .reg 备份（读操作，普通权限即可）。失败返回 Err。
+fn backup_reg(full: &str, subpath: &str) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    let dir = reg_backup_dir().ok_or("无法创建注册表备份目录")?;
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let safe: String = subpath
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect();
+    let backup = dir.join(format!("{}_{}.reg", safe, stamp));
+    let status = std::process::Command::new("reg")
+        .args(["export", full, &backup.to_string_lossy(), "/y"])
+        .creation_flags(CREATE_NO_WINDOW)
+        .status();
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        _ => Err("导出注册表备份失败，已中止删除以保安全。".to_string()),
+    }
+}
+
+/// 注册表键是否仍存在（HKLM 普通用户可读，用于验证提权删除结果）。
+fn reg_exists(hive: winreg::HKEY, subpath: &str) -> bool {
+    RegKey::predef(hive)
+        .open_subkey_with_flags(subpath, KEY_READ)
+        .is_ok()
+}
+
+/// 判断文件夹删除是否需要管理员权限（位于 ProgramData / Program Files / Windows 等受保护位置）。
+fn dir_needs_elevation(path: &str) -> bool {
+    let p = norm(path);
+    for var in [
+        "ProgramData",
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "ProgramW6432",
+        "SystemRoot",
+    ] {
+        if let Some(root) = std::env::var_os(var) {
+            let r = norm(&root.to_string_lossy());
+            if !r.is_empty() && p.starts_with(&r) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// 一次性提权执行一批命令（单次 UAC）：写 GBK 编码临时 bat，用 Start-Process RunAs 执行。
+/// 用于删除受保护文件夹（rmdir）与 HKLM 注册表项（reg delete）；中文路径用 GBK 规避 cmd 乱码。
+fn run_elevated_batch(lines: &[String]) -> Result<(), String> {
+    use std::os::windows::process::CommandExt;
+    let bat = std::env::temp_dir().join("diskbutler-cleanup.bat");
+    let mut content = String::from("@echo off\r\n");
+    for l in lines {
+        content.push_str(l);
+        content.push_str("\r\n");
+    }
+    content.push_str("exit /b 0\r\n");
+    let (gbk, _, _) = encoding_rs::GBK.encode(&content);
+    std::fs::write(&bat, &gbk).map_err(|e| format!("写入清理脚本失败：{}", e))?;
+
+    let ps = format!(
+        r#"$p = Start-Process -Verb RunAs -WindowStyle Hidden -Wait -PassThru -FilePath cmd.exe -ArgumentList '/c','"{}"'; exit $p.ExitCode"#,
+        bat.display()
+    );
+    let status = std::process::Command::new("powershell")
+        .args(["-NoProfile", "-Command", &ps])
+        .creation_flags(CREATE_NO_WINDOW)
+        .status()
+        .map_err(|e| format!("提权操作失败：{}", e))?;
+    let _ = std::fs::remove_file(&bat);
+    match status.code().unwrap_or(-1) {
+        0 => Ok(()),
+        1 => Err("已取消管理员授权，需要权限的项未清理。".to_string()),
+        c => Err(format!("提权清理未完成（退出码 {}）。", c)),
+    }
+}
+
+/// 待提权处理的目标（批处理后逐项验证成败）。
+struct ElevTarget {
+    path: String,
+    is_dir: bool,
+    reg_subpath: String,
+}
+
+/// 删除前端勾选的残留项。
+/// 普通文件夹入回收站、HKCU 注册表直删；受保护文件夹与 HKLM 注册表合并为一次提权批处理（单次 UAC，不会隐藏阻塞）。
+pub fn remove_leftovers(items: Vec<LeftoverInput>) -> Vec<RemoveResult> {
+    let mut results = Vec::new();
+    let mut lines: Vec<String> = Vec::new();
+    let mut targets: Vec<ElevTarget> = Vec::new();
+
+    for item in items {
+        match item.kind.as_str() {
+            "dir" => {
+                let p = PathBuf::from(&item.path);
+                if !p.is_dir() {
+                    results.push(RemoveResult {
+                        path: item.path,
+                        ok: false,
+                        error: Some("目录不存在或已删除".to_string()),
+                    });
+                    continue;
+                }
+                // 命令行路径去掉尾部反斜杠，避免 cmd 中 `\"` 转义闭合引号
+                let cmd_path = item.path.trim_end_matches('\\').to_string();
+                if dir_needs_elevation(&item.path) {
+                    lines.push(format!(r#"rmdir /s /q "{}""#, cmd_path));
+                    targets.push(ElevTarget {
+                        path: item.path,
+                        is_dir: true,
+                        reg_subpath: String::new(),
+                    });
+                } else {
+                    match send_dir_to_recycle(&item.path) {
+                        Ok(()) => results.push(RemoveResult {
+                            path: item.path,
+                            ok: true,
+                            error: None,
+                        }),
+                        // 用户目录无需提权，回收失败通常是文件被占用（如正在运行的程序）；
+                        // 不再升级为提权永久删除（避免删坏运行中程序的数据），如实报告
+                        Err(_) => results.push(RemoveResult {
+                            path: item.path,
+                            ok: false,
+                            error: Some(
+                                "删除失败（文件可能正被占用，请先关闭相关程序后重试）".to_string(),
+                            ),
+                        }),
+                    }
+                }
+            }
+            "reg" => match ensure_software_branch(&item.path) {
+                Err(e) => results.push(RemoveResult {
+                    path: item.path,
+                    ok: false,
+                    error: Some(e),
+                }),
+                Ok((hive, subpath)) => {
+                    if let Err(e) = backup_reg(&item.path, &subpath) {
+                        results.push(RemoveResult {
+                            path: item.path,
+                            ok: false,
+                            error: Some(e),
+                        });
+                        continue;
+                    }
+                    if hive == HKEY_CURRENT_USER {
+                        let r = RegKey::predef(hive)
+                            .delete_subkey_all(&subpath)
+                            .map_err(|e| format!("删除注册表项失败：{}", e));
+                        results.push(RemoveResult {
+                            path: item.path,
+                            ok: r.is_ok(),
+                            error: r.err(),
+                        });
+                    } else {
+                        lines.push(format!(r#"reg delete "{}" /f"#, item.path));
+                        targets.push(ElevTarget {
+                            path: item.path,
+                            is_dir: false,
+                            reg_subpath: subpath,
+                        });
+                    }
+                }
+            },
+            _ => results.push(RemoveResult {
+                path: item.path,
+                ok: false,
+                error: Some("未知的残留类型".to_string()),
+            }),
+        }
+    }
+
+    // 一次性提权批处理受保护文件夹 + HKLM 注册表，再逐项按“是否已消失”验证成败
+    if !lines.is_empty() {
+        let batch = run_elevated_batch(&lines);
+        for t in targets {
+            let gone = if t.is_dir {
+                !PathBuf::from(&t.path).exists()
+            } else {
+                !reg_exists(HKEY_LOCAL_MACHINE, &t.reg_subpath)
+            };
+            let error = if gone {
+                None
+            } else {
+                Some(
+                    batch
+                        .as_ref()
+                        .err()
+                        .cloned()
+                        .unwrap_or_else(|| "清理失败（可能需要管理员权限）".to_string()),
+                )
+            };
+            results.push(RemoveResult {
+                path: t.path,
+                ok: gone,
+                error,
+            });
+        }
+    }
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generic_names_are_rejected() {
+        assert!(is_generic("Microsoft"));
+        assert!(is_generic("common files"));
+        assert!(is_generic(""));
+        assert!(!is_generic("Everything"));
+        assert!(!is_generic("剪映"));
+    }
+
+    #[test]
+    fn split_command_handles_quoted_and_plain() {
+        let (e, a) = split_command("\"C:\\Program Files\\App\\uninstall.exe\" /S");
+        assert_eq!(e, "C:\\Program Files\\App\\uninstall.exe");
+        assert_eq!(a, "/S");
+        let (e2, a2) = split_command("C:\\App\\unins000.exe /SILENT");
+        assert_eq!(e2, "C:\\App\\unins000.exe");
+        assert_eq!(a2, "/SILENT");
+        let (e3, a3) = split_command("MsiExec.exe");
+        assert_eq!(e3, "MsiExec.exe");
+        assert_eq!(a3, "");
+    }
+
+    #[test]
+    fn split_reg_parses_hive_prefix() {
+        let (h, p) = split_reg(r"HKCU\Software\Foo").unwrap();
+        assert_eq!(h, HKEY_CURRENT_USER);
+        assert_eq!(p, r"Software\Foo");
+        assert!(split_reg("BADHIVE\\x").is_none());
+    }
+
+    #[test]
+    fn delete_reg_rejects_non_software_branch() {
+        // 系统关键分支必须被拒绝，绝不允许误删
+        assert!(ensure_software_branch(r"HKLM\SYSTEM\CurrentControlSet").is_err());
+        assert!(ensure_software_branch(r"HKCU\Software\Foo").is_ok());
+    }
+
+    #[test]
+    fn strip_version_suffix_trims_trailing_version() {
+        assert_eq!(strip_version_suffix("ocs desktop 2.8.5"), "ocs desktop");
+        assert_eq!(strip_version_suffix("everything"), "everything");
+        // 纯版本名不能被删空
+        assert_eq!(strip_version_suffix("1.2.3"), "1.2.3");
+    }
+
+    #[test]
+    fn reg_name_match_matches_exact_and_versioned() {
+        assert_eq!(reg_name_match("ocs desktop", "ocs desktop 2.8.5", "ocs desktop"), Some("high"));
+        assert_eq!(reg_name_match("everything", "everything", "everything"), Some("high"));
+        // 泛词与不相关名不命中
+        assert!(reg_name_match("microsoft", "microsoft office", "microsoft office").is_none());
+        assert!(reg_name_match("chrome", "firefox", "firefox").is_none());
+    }
+}

--- a/src-tauri/src/uninstall.rs
+++ b/src-tauri/src/uninstall.rs
@@ -251,28 +251,30 @@ pub fn list_installed() -> Vec<InstalledApp> {
         }
     }
 
-    apps.extend(list_uwp());
     apps.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
     apps
 }
 
 /// 枚举可卸载的 UWP/商店应用（Get-AppxPackage），解析友好名与包内 logo。
 /// 过滤框架包/系统包/不可卸载项；DisplayName 为 ms-resource 时退回包名末段。
-fn list_uwp() -> Vec<InstalledApp> {
+pub fn list_uwp() -> Vec<InstalledApp> {
     use std::os::windows::process::CommandExt;
     let script = r#"[Console]::OutputEncoding=[System.Text.Encoding]::UTF8
 $ErrorActionPreference='SilentlyContinue'
 $apps = Get-AppxPackage | Where-Object { -not $_.IsFramework -and -not $_.NonRemovable -and $_.SignatureKind -ne 'System' }
 $list = foreach ($p in $apps) {
   $dn=''; $logo=''; $pub=''
-  try {
-    $m = Get-AppxPackageManifest -Package $p.PackageFullName
-    $dn = [string]$m.Package.Properties.DisplayName
-    $pub = [string]$m.Package.Properties.PublisherDisplayName
-    $logo = [string]$m.Package.Properties.Logo
-    $vdn = [string]$m.Package.Applications.Application.VisualElements.DisplayName
-    if (($dn -eq '' -or $dn -like 'ms-resource:*') -and $vdn -and $vdn -notlike 'ms-resource:*') { $dn = $vdn }
-  } catch {}
+  $mf = Join-Path $p.InstallLocation 'AppxManifest.xml'
+  if ($p.InstallLocation -and (Test-Path -LiteralPath $mf)) {
+    try {
+      [xml]$x = Get-Content -LiteralPath $mf -Raw -Encoding UTF8
+      $dn = [string]$x.Package.Properties.DisplayName
+      $pub = [string]$x.Package.Properties.PublisherDisplayName
+      $logo = [string]$x.Package.Properties.Logo
+      $vdn = [string]$x.Package.Applications.Application.VisualElements.DisplayName
+      if (($dn -eq '' -or $dn -like 'ms-resource:*') -and $vdn -and $vdn -notlike 'ms-resource:*') { $dn = $vdn }
+    } catch {}
+  }
   if (-not $dn -or $dn -like 'ms-resource:*') { $dn = ($p.Name -split '\.')[-1] }
   $logoPath=''
   if ($p.InstallLocation -and $logo) {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 800,
         "minWidth": 980,
         "minHeight": 660,
-        "center": true
+        "center": true,
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react";
-import { HardDrive, Sparkles, Rocket, Cpu, Trash2, ShieldCheck, HeartHandshake } from "lucide-react";
+import { HardDrive, Sparkles, Rocket, Cpu, Trash2, Zap, ShieldCheck, HeartHandshake } from "lucide-react";
 import DiskInsight from "./pages/DiskInsight";
 import Cleanup from "./pages/Cleanup";
 import Startup from "./pages/Startup";
 import MemoryCheck from "./pages/MemoryCheck";
 import Uninstall from "./pages/Uninstall";
+import ForceDelete from "./pages/ForceDelete";
 import ContributeModal from "./components/ContributeModal";
 
-type PageId = "insight" | "clean" | "uninstall" | "startup" | "memory";
+type PageId = "insight" | "clean" | "uninstall" | "forcedelete" | "startup" | "memory";
 
 interface NavItem {
   id: PageId;
@@ -20,6 +21,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: "insight", label: "磁盘透视", icon: <HardDrive size={20} />, ready: true },
   { id: "clean", label: "一键清理", icon: <Sparkles size={20} />, ready: true },
   { id: "uninstall", label: "软件卸载", icon: <Trash2 size={20} />, ready: true },
+  { id: "forcedelete", label: "强力删除", icon: <Zap size={20} />, ready: true },
   { id: "startup", label: "启动管理", icon: <Rocket size={20} />, ready: true },
   { id: "memory", label: "内存体检", icon: <Cpu size={20} />, ready: true },
 ];
@@ -116,6 +118,11 @@ function App() {
         {visited.has("uninstall") && (
           <div className={page === "uninstall" ? "h-full" : "hidden"}>
             <Uninstall />
+          </div>
+        )}
+        {visited.has("forcedelete") && (
+          <div className={page === "forcedelete" ? "h-full" : "hidden"}>
+            <ForceDelete active={page === "forcedelete"} />
           </div>
         )}
         {visited.has("startup") && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
-import { HardDrive, Sparkles, Rocket, Cpu, ShieldCheck, HeartHandshake } from "lucide-react";
+import { HardDrive, Sparkles, Rocket, Cpu, Trash2, ShieldCheck, HeartHandshake } from "lucide-react";
 import DiskInsight from "./pages/DiskInsight";
 import Cleanup from "./pages/Cleanup";
 import Startup from "./pages/Startup";
 import MemoryCheck from "./pages/MemoryCheck";
+import Uninstall from "./pages/Uninstall";
 import ContributeModal from "./components/ContributeModal";
 
-type PageId = "insight" | "clean" | "startup" | "memory";
+type PageId = "insight" | "clean" | "uninstall" | "startup" | "memory";
 
 interface NavItem {
   id: PageId;
@@ -18,6 +19,7 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { id: "insight", label: "磁盘透视", icon: <HardDrive size={20} />, ready: true },
   { id: "clean", label: "一键清理", icon: <Sparkles size={20} />, ready: true },
+  { id: "uninstall", label: "软件卸载", icon: <Trash2 size={20} />, ready: true },
   { id: "startup", label: "启动管理", icon: <Rocket size={20} />, ready: true },
   { id: "memory", label: "内存体检", icon: <Cpu size={20} />, ready: true },
 ];
@@ -95,7 +97,7 @@ function App() {
         </div>
 
         <div className="px-5 pb-4 text-[11px] leading-relaxed text-[var(--color-text-secondary)]">
-          v{__APP_VERSION__.split(".").slice(0, 2).join(".")} · 透视 / 清理 / 启动 / 内存
+          v{__APP_VERSION__.split(".").slice(0, 2).join(".")} · 透视 / 清理 / 卸载 / 启动 / 内存
           <br />
           所有操作都会先告诉你“这是什么”
         </div>
@@ -109,6 +111,11 @@ function App() {
         {visited.has("clean") && (
           <div className={page === "clean" ? "h-full" : "hidden"}>
             <Cleanup />
+          </div>
+        )}
+        {visited.has("uninstall") && (
+          <div className={page === "uninstall" ? "h-full" : "hidden"}>
+            <Uninstall />
           </div>
         )}
         {visited.has("startup") && (

--- a/src/components/ForceDeleteModal.tsx
+++ b/src/components/ForceDeleteModal.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { motion } from "framer-motion";
+import { Loader2, ShieldAlert, Zap, CheckCircle2, AlertTriangle } from "lucide-react";
+import { LockingProcess } from "../types";
+
+/**
+ * 强力删除弹窗：检测占用某文件/文件夹的进程 → 让用户确认关闭 → 终止后删除（移入回收站可恢复）。
+ * 供「独立强力删除页」与「软件卸载·残留清理」复用。
+ */
+export default function ForceDeleteModal({
+  path,
+  onClose,
+  onDeleted,
+}: {
+  path: string;
+  onClose: () => void;
+  onDeleted?: (path: string) => void;
+}) {
+  const [loading, setLoading] = useState(true);
+  const [procs, setProcs] = useState<LockingProcess[]>([]);
+  const [checked, setChecked] = useState<Set<number>>(new Set());
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState("");
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    invoke<LockingProcess[]>("find_file_lockers", { path })
+      .then((list) => {
+        if (!alive) return;
+        setProcs(list);
+        // 默认勾选所有“非系统关键”进程
+        setChecked(new Set(list.filter((p) => !p.isCritical).map((p) => p.pid)));
+      })
+      .catch((e) => alive && setError(String(e)))
+      .finally(() => alive && setLoading(false));
+    return () => {
+      alive = false;
+    };
+  }, [path]);
+
+  function toggle(pid: number) {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      next.has(pid) ? next.delete(pid) : next.add(pid);
+      return next;
+    });
+  }
+
+  async function run() {
+    setWorking(true);
+    setError("");
+    try {
+      const pids = Array.from(checked);
+      await invoke("force_delete_path", { path, pids, toRecycle: true });
+      setDone(true);
+      onDeleted?.(path);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  const killable = procs.filter((p) => !p.isCritical);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-6"
+      onClick={onClose}
+    >
+      <motion.div
+        initial={{ scale: 0.96, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.96, opacity: 0 }}
+        onClick={(e) => e.stopPropagation()}
+        className="flex max-h-[80vh] w-[520px] flex-col overflow-hidden rounded-2xl bg-[var(--color-surface)] shadow-xl"
+      >
+        {/* 头部 */}
+        <div className="flex items-start gap-3 border-b border-[var(--color-line)] px-6 py-4">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-[var(--color-caution)]/15 text-[var(--color-caution)]">
+            <Zap size={18} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-base font-semibold">强力删除</div>
+            <div className="mt-0.5 truncate text-xs text-[var(--color-text-secondary)]" title={path}>
+              {path}
+            </div>
+          </div>
+        </div>
+
+        {/* 主体 */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {loading ? (
+            <div className="flex items-center gap-2 py-6 text-sm text-[var(--color-text-secondary)]">
+              <Loader2 size={16} className="animate-spin" />
+              正在检测占用进程…
+            </div>
+          ) : done ? (
+            <div className="flex items-center gap-2 py-6 text-sm text-[var(--color-safe)]">
+              <CheckCircle2 size={18} />
+              已删除（文件已移入回收站，可恢复）
+            </div>
+          ) : procs.length === 0 ? (
+            <div className="py-2 text-sm text-[var(--color-text-main)]">
+              没有检测到占用进程。删除失败可能是权限或其他原因，可直接尝试强力删除（受保护位置会请求一次管理员授权）。
+            </div>
+          ) : (
+            <>
+              <div className="mb-3 text-sm text-[var(--color-text-main)]">
+                以下程序正占用它，关闭后即可删除：
+              </div>
+              <div className="flex flex-col gap-1.5">
+                {procs.map((p) => (
+                  <label
+                    key={p.pid}
+                    className={[
+                      "flex items-center gap-2.5 rounded-lg border px-3 py-2",
+                      p.isCritical
+                        ? "cursor-not-allowed border-[var(--color-line)] bg-[var(--color-bg)] opacity-60"
+                        : "cursor-pointer border-[var(--color-line)] bg-[var(--color-bg)]",
+                    ].join(" ")}
+                  >
+                    <input
+                      type="checkbox"
+                      disabled={p.isCritical}
+                      checked={checked.has(p.pid)}
+                      onChange={() => toggle(p.pid)}
+                      className="h-4 w-4 shrink-0 accent-[var(--color-primary)]"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm text-[var(--color-text-main)]">{p.name}</div>
+                      <div className="text-[11px] text-[var(--color-text-secondary)]">PID {p.pid}</div>
+                    </div>
+                    {p.isCritical && (
+                      <span className="flex shrink-0 items-center gap-1 text-[11px] text-[var(--color-caution)]">
+                        <ShieldAlert size={12} />
+                        系统关键进程，不可关闭
+                      </span>
+                    )}
+                  </label>
+                ))}
+              </div>
+            </>
+          )}
+
+          {error && (
+            <div className="mt-3 flex items-start gap-1.5 rounded-lg bg-[var(--color-caution)]/10 px-3 py-2 text-xs text-[var(--color-caution)]">
+              <AlertTriangle size={13} className="mt-0.5 shrink-0" />
+              <span className="min-w-0 flex-1">{error}</span>
+            </div>
+          )}
+        </div>
+
+        {/* 底部按钮 */}
+        <div className="flex items-center justify-end gap-2 border-t border-[var(--color-line)] px-6 py-3">
+          <button
+            onClick={onClose}
+            className="rounded-xl px-4 py-2 text-sm text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg)]"
+          >
+            {done ? "关闭" : "取消"}
+          </button>
+          {!done && !loading && (
+            <button
+              onClick={run}
+              disabled={working}
+              className="flex items-center gap-2 rounded-xl bg-[var(--color-caution)] px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+            >
+              {working ? (
+                <Loader2 size={15} className="animate-spin" />
+              ) : (
+                <Zap size={15} />
+              )}
+              {killable.length > 0 ? `关闭并删除 (${checked.size})` : "直接强力删除"}
+            </button>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,15 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/tokens.css";
 
+// 禁用 WebView 默认右键菜单（浏览器那套返回/刷新/检查）；
+// 仅在输入框等可编辑元素保留系统菜单，方便复制/粘贴。
+document.addEventListener("contextmenu", (e) => {
+  const el = e.target as HTMLElement | null;
+  if (!el || !el.closest('input, textarea, [contenteditable="true"]')) {
+    e.preventDefault();
+  }
+});
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />

--- a/src/pages/ForceDelete.tsx
+++ b/src/pages/ForceDelete.tsx
@@ -1,0 +1,128 @@
+import { useState, useEffect, useRef } from "react";
+import { AnimatePresence } from "framer-motion";
+import { listen } from "@tauri-apps/api/event";
+import { Zap, FolderInput, ShieldCheck, UploadCloud } from "lucide-react";
+import ForceDeleteModal from "../components/ForceDeleteModal";
+
+/**
+ * 强力删除工具页：粘贴或拖入一个被占用、删不掉的文件/文件夹路径，
+ * 检测占用它的进程 → 确认关闭 → 终止后删除（移入回收站可恢复）。
+ */
+export default function ForceDelete({ active }: { active: boolean }) {
+  const [path, setPath] = useState("");
+  const [target, setTarget] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // 拖放事件是整窗口级的，用 ref 保证只在本页可见时响应
+  const activeRef = useRef(active);
+  activeRef.current = active;
+
+  const trimmed = path.trim().replace(/^"|"$/g, ""); // 容忍“复制为路径”带的引号
+
+  useEffect(() => {
+    // Tauri v2 在 Windows 上 webview 级 onDragDropEvent 常不触发，
+    // 改监听全局原生事件 tauri://drag-*（官方 issue/社区验证可用）。
+    const uns: Promise<() => void>[] = [];
+    uns.push(
+      listen<{ paths: string[] }>("tauri://drag-drop", (e) => {
+        if (!activeRef.current) return;
+        setDragging(false);
+        const first = e.payload?.paths?.[0];
+        if (first) {
+          setPath(first);
+          setTarget(first); // 拖入即检测占用（仍需在弹窗里确认后才真正删除）
+        }
+      }),
+    );
+    uns.push(listen("tauri://drag-enter", () => activeRef.current && setDragging(true)));
+    uns.push(listen("tauri://drag-over", () => activeRef.current && setDragging(true)));
+    uns.push(listen("tauri://drag-leave", () => setDragging(false)));
+    return () => {
+      uns.forEach((u) => u.then((f) => f()));
+    };
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* 标题 */}
+      <header className="px-8 pt-6 pb-2">
+        <h1 className="text-xl font-semibold">强力删除</h1>
+        <p className="mt-0.5 text-sm text-[var(--color-text-secondary)]">
+          删不掉、提示“文件正在使用”的文件或文件夹，用这里找出占用它的程序，关闭后删除（先进回收站可恢复）
+        </p>
+      </header>
+
+      {/* 操作区 */}
+      <div className="mx-8 mt-2 flex flex-col gap-4 rounded-2xl bg-[var(--color-surface)] p-6 shadow-[var(--shadow-card)]">
+        {/* 拖入区 */}
+        <div
+          className={[
+            "flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed py-20 transition-colors",
+            dragging
+              ? "border-[var(--color-caution)] bg-[var(--color-caution)]/10"
+              : "border-[var(--color-line)] bg-[var(--color-bg)]",
+          ].join(" ")}
+        >
+          <UploadCloud
+            size={48}
+            className={dragging ? "text-[var(--color-caution)]" : "text-[var(--color-text-secondary)]"}
+          />
+          <div className="text-base text-[var(--color-text-main)]">
+            {dragging ? "松开鼠标，载入该文件 / 文件夹" : "把要删除的文件或文件夹拖到这里"}
+          </div>
+          <div className="text-xs text-[var(--color-text-secondary)]">或在下方粘贴完整路径</div>
+        </div>
+
+        <div>
+          <label className="mb-1.5 block text-sm font-medium text-[var(--color-text-main)]">
+            文件 / 文件夹路径
+          </label>
+          <div className="flex items-center gap-2.5">
+            <div className="relative flex-1">
+              <FolderInput
+                size={18}
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)]"
+              />
+              <input
+                value={path}
+                onChange={(e) => setPath(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && trimmed) setTarget(trimmed);
+                }}
+                placeholder="例如 C:\\Program Files\\顽固软件\\locked.exe"
+                className="w-full rounded-xl border border-[var(--color-line)] bg-[var(--color-bg)] py-2.5 pl-10 pr-3 text-sm outline-none focus:border-[var(--color-primary)]"
+              />
+            </div>
+            <button
+              onClick={() => trimmed && setTarget(trimmed)}
+              disabled={!trimmed}
+              className="flex shrink-0 items-center gap-2 rounded-xl bg-[var(--color-caution)] px-4 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+            >
+              <Zap size={16} />
+              检测占用并删除
+            </button>
+          </div>
+        </div>
+
+        {/* 安全说明 */}
+        <div className="flex items-start gap-2 rounded-xl border border-[var(--color-line)] px-4 py-3 text-xs leading-relaxed text-[var(--color-text-secondary)]">
+          <ShieldCheck size={14} className="mt-0.5 shrink-0 text-[var(--color-safe)]" />
+          <div>
+            删除默认<b>移入回收站</b>可恢复；系统关键进程（如 lsass、csrss 等）<b>不会</b>被关闭；
+            关闭被占用的程序前请先自行保存其中未存的工作。
+          </div>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {target && (
+          <ForceDeleteModal
+            path={target}
+            onClose={() => setTarget(null)}
+            onDeleted={() => setPath("")}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/pages/Uninstall.tsx
+++ b/src/pages/Uninstall.tsx
@@ -1,0 +1,564 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  Trash2,
+  Loader2,
+  Search,
+  Package,
+  RotateCcw,
+  FolderOpen,
+  KeyRound,
+  ShieldCheck,
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+} from "lucide-react";
+import { InstalledApp, LeftoverItem, RemoveResult, formatBytes } from "../types";
+
+type Phase = "loading" | "ready";
+
+/** 残留清单弹窗的数据：来源软件名 + 合并后的残留项 */
+interface LeftoverView {
+  appNames: string[];
+  items: LeftoverItem[];
+}
+
+const leftoverKey = (it: { kind: string; path: string }) => `${it.kind}::${it.path}`;
+
+export default function Uninstall() {
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [apps, setApps] = useState<InstalledApp[]>([]);
+  const [error, setError] = useState("");
+  const [query, setQuery] = useState("");
+  /** 批量选中的软件 id */
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  /** 卸载器执行中的遮罩（等待原生向导完成）*/
+  const [busy, setBusy] = useState<string>("");
+
+  /** 残留清单弹窗 */
+  const [leftover, setLeftover] = useState<LeftoverView | null>(null);
+  const [leftoverChecked, setLeftoverChecked] = useState<Set<string>>(new Set());
+  const [removing, setRemoving] = useState(false);
+  const [removeResults, setRemoveResults] = useState<RemoveResult[] | null>(null);
+
+  /** 图标缓存：按 app.id（回退会用到 installLocation，不能只按 iconPath 缓存） */
+  const [icons, setIcons] = useState<Record<string, string>>({});
+  const requestedIcons = useRef<Set<string>>(new Set());
+
+  async function load(): Promise<InstalledApp[]> {
+    const list = await invoke<InstalledApp[]>("list_installed_apps");
+    setApps(list);
+    return list;
+  }
+
+  /** 轮询等待指定软件从列表消失（很多卸载器子进程异步执行，进程返回时注册表键还在）。 */
+  async function waitGone(ids: string[], timeoutMs = 12000): Promise<InstalledApp[]> {
+    const start = Date.now();
+    let list = await load();
+    while (ids.some((id) => list.some((a) => a.id === id)) && Date.now() - start < timeoutMs) {
+      await new Promise((r) => setTimeout(r, 800));
+      list = await load();
+    }
+    return list;
+  }
+
+  useEffect(() => {
+    load()
+      .then(() => setPhase("ready"))
+      .catch((e) => {
+        setError(String(e));
+        setPhase("ready");
+      });
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return apps;
+    return apps.filter(
+      (a) =>
+        a.name.toLowerCase().includes(q) || a.publisher.toLowerCase().includes(q),
+    );
+  }, [apps, query]);
+
+  // 按需拉取图标：每个软件只请求一次（按 id 去重）；DisplayIcon 与安装目录均交给后端走兑底链
+  useEffect(() => {
+    for (const app of filtered) {
+      if (requestedIcons.current.has(app.id)) continue;
+      if (!app.iconPath && !app.installLocation) continue;
+      requestedIcons.current.add(app.id);
+      invoke<string | null>("app_icon", {
+        iconPath: app.iconPath,
+        installLocation: app.installLocation,
+        uninstallString: app.uninstallString,
+        name: app.name,
+      })
+        .then((uri) => {
+          if (uri) setIcons((prev) => ({ ...prev, [app.id]: uri }));
+        })
+        .catch(() => {});
+    }
+  }, [filtered]);
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }
+
+  /** 打开残留弹窗：高置信度项默认勾选，低置信度默认不勾（保守） */
+  function openLeftovers(appNames: string[], items: LeftoverItem[]) {
+    if (items.length === 0) return;
+    setLeftover({ appNames, items });
+    setLeftoverChecked(
+      new Set(items.filter((it) => it.confidence === "high").map(leftoverKey)),
+    );
+    setRemoveResults(null);
+  }
+
+  /** 卸载单个软件：调原生卸载器 → 轮询确认已消失 → 扫残留 */
+  async function uninstallOne(app: InstalledApp) {
+    setError("");
+    setBusy(`正在等待「${app.name}」的卸载程序完成…`);
+    try {
+      await invoke<number>("run_app_uninstaller", { id: app.id });
+      // 卸载器常在子进程里继续执行，轮询等待它真正从列表消失
+      setBusy(`正在确认「${app.name}」的卸载结果…`);
+      const after = await waitGone([app.id]);
+      // 超时仍在列表：卸载未完成（用户取消/失败），绝不扫描删除其文件
+      if (after.some((a) => a.id === app.id)) {
+        setBusy("");
+        return;
+      }
+      // 商店应用（UWP）由系统整包移除，无残留需清理
+      if (app.id.startsWith("uwp|")) {
+        setBusy("");
+        return;
+      }
+      setBusy(`正在扫描「${app.name}」的残留…`);
+      const items = await invoke<LeftoverItem[]>("scan_app_leftovers", {
+        name: app.name,
+        publisher: app.publisher,
+        installLocation: app.installLocation,
+      });
+      setBusy("");
+      openLeftovers([app.name], items);
+    } catch (e) {
+      setError(String(e));
+      setBusy("");
+    }
+  }
+
+  /** 批量卸载（向导模式）：逐个弹原生向导，全部结束后轮询确认并合并扫描残留 */
+  async function uninstallBatch() {
+    const targets = apps.filter((a) => selected.has(a.id));
+    if (targets.length === 0) return;
+    setError("");
+    try {
+      for (let i = 0; i < targets.length; i++) {
+        const app = targets[i];
+        setBusy(`（${i + 1}/${targets.length}）正在等待「${app.name}」的卸载程序完成…`);
+        await invoke<number>("run_app_uninstaller", { id: app.id });
+      }
+      setBusy("正在确认卸载结果…");
+      const after = await waitGone(targets.map((t) => t.id));
+      const gone = targets.filter((t) => !after.some((a) => a.id === t.id));
+      const merged: LeftoverItem[] = [];
+      const seen = new Set<string>();
+      for (const app of gone) {
+        if (app.id.startsWith("uwp|")) continue; // 商店应用无残留
+        const items = await invoke<LeftoverItem[]>("scan_app_leftovers", {
+          name: app.name,
+          publisher: app.publisher,
+          installLocation: app.installLocation,
+        });
+        for (const it of items) {
+          if (seen.add(leftoverKey(it))) merged.push(it);
+        }
+      }
+      setBusy("");
+      setSelected(new Set());
+      openLeftovers(gone.map((a) => a.name), merged);
+    } catch (e) {
+      setError(String(e));
+      setBusy("");
+    }
+  }
+
+  function toggleLeftover(key: string) {
+    setLeftoverChecked((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  }
+
+  async function removeLeftovers() {
+    if (!leftover) return;
+    const items = leftover.items
+      .filter((it) => leftoverChecked.has(leftoverKey(it)))
+      .map((it) => ({ kind: it.kind, path: it.path }));
+    if (items.length === 0) return;
+    setRemoving(true);
+    try {
+      const results = await invoke<RemoveResult[]>("remove_app_leftovers", { items });
+      setRemoveResults(results);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setRemoving(false);
+    }
+  }
+
+  const dirItems = leftover?.items.filter((it) => it.kind === "dir") ?? [];
+  const regItems = leftover?.items.filter((it) => it.kind === "reg") ?? [];
+  const selectedCount = selected.size;
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* 顶部标题 */}
+      <header className="px-8 pt-6 pb-2">
+        <h1 className="text-xl font-semibold">软件卸载</h1>
+        <p className="mt-0.5 text-sm text-[var(--color-text-secondary)]">
+          彻底卸载软件并清理残留文件与注册表项，支持批量。残留删除前会先备份、文件可从回收站找回
+        </p>
+      </header>
+
+      {/* 控制条 */}
+      <div className="mx-8 mt-2 flex items-center gap-4 rounded-2xl bg-[var(--color-surface)] p-4 shadow-[var(--shadow-card)]">
+        <div className="relative flex-1">
+          <Search
+            size={18}
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--color-text-secondary)]"
+          />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="搜索软件名称或发行商…"
+            className="w-full rounded-xl border border-[var(--color-line)] bg-[var(--color-bg)] py-2.5 pl-10 pr-3 text-sm outline-none focus:border-[var(--color-primary)]"
+          />
+        </div>
+        <span className="shrink-0 text-sm text-[var(--color-text-secondary)]">
+          共 <span className="font-semibold text-[var(--color-text-main)]">{apps.length}</span> 个
+        </span>
+        <button
+          onClick={() => {
+            requestedIcons.current.clear();
+            load().catch((e) => setError(String(e)));
+          }}
+          disabled={!!busy}
+          title="刷新列表"
+          className="flex shrink-0 items-center gap-1.5 rounded-xl border border-[var(--color-line)] px-3 py-2.5 text-sm transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary-dark)] disabled:opacity-40"
+        >
+          <RotateCcw size={16} />
+          刷新
+        </button>
+        {selectedCount > 0 && (
+          <button
+            onClick={() => setSelected(new Set())}
+            disabled={!!busy}
+            title="取消全部勾选"
+            className="flex shrink-0 items-center gap-1.5 rounded-xl border border-[var(--color-line)] px-3 py-2.5 text-sm transition-colors hover:border-[var(--color-caution)] hover:text-[var(--color-caution)] disabled:opacity-40"
+          >
+            <XCircle size={16} />
+            清空 ({selectedCount})
+          </button>
+        )}
+        <button
+          onClick={uninstallBatch}
+          disabled={selectedCount < 2 || !!busy}
+          className="flex shrink-0 items-center gap-2 rounded-xl bg-[var(--color-primary)] px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[var(--color-primary-dark)] disabled:opacity-40"
+        >
+          <Trash2 size={16} />
+          批量卸载{selectedCount >= 2 ? ` (${selectedCount})` : ""}
+        </button>
+      </div>
+
+      {/* 主体：软件列表 */}
+      <div className="flex-1 overflow-y-auto px-8 py-5">
+        {error && (
+          <div className="mb-4 rounded-xl bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-caution)] shadow-[var(--shadow-card)]">
+            出了点问题：{error}
+          </div>
+        )}
+
+        {phase === "loading" ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 text-[var(--color-text-secondary)]">
+            <Loader2 size={32} className="animate-spin text-[var(--color-primary)]" />
+            正在读取已安装的软件…
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-[var(--color-text-secondary)]">
+            <Package size={36} className="opacity-40" />
+            {query ? "没有匹配的软件" : "没有找到可卸载的软件"}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {filtered.map((app, i) => {
+              const active = selected.has(app.id);
+              return (
+                <div
+                  key={`${app.id}#${i}`}
+                  className={[
+                    "flex items-center gap-3 rounded-xl border bg-[var(--color-surface)] px-4 py-3 transition-colors",
+                    active
+                      ? "border-[var(--color-primary)]"
+                      : "border-[var(--color-line)] hover:border-[var(--color-primary-soft)]",
+                  ].join(" ")}
+                >
+                  <input
+                    type="checkbox"
+                    checked={active}
+                    onChange={() => toggleSelect(app.id)}
+                    className="h-4 w-4 shrink-0 accent-[var(--color-primary)]"
+                  />
+                  <div className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[var(--color-primary-soft)] text-[var(--color-primary-dark)]">
+                    {icons[app.id] ? (
+                      <img
+                        src={icons[app.id]}
+                        alt=""
+                        className="h-7 w-7 object-contain"
+                        draggable={false}
+                      />
+                    ) : (
+                      <Package size={18} />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium">
+                      {app.name}
+                      {app.version && (
+                        <span className="ml-2 text-xs font-normal text-[var(--color-text-secondary)]">
+                          {app.version}
+                        </span>
+                      )}
+                    </div>
+                    <div className="truncate text-xs text-[var(--color-text-secondary)]">
+                      {app.publisher || "未知发行商"}
+                    </div>
+                  </div>
+                  {app.size > 0 && (
+                    <span className="shrink-0 text-xs text-[var(--color-text-secondary)]">
+                      {formatBytes(app.size)}
+                    </span>
+                  )}
+                  <button
+                    onClick={() => uninstallOne(app)}
+                    disabled={!!busy}
+                    className="flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--color-line)] px-3 py-1.5 text-xs font-medium transition-colors hover:border-[var(--color-primary)] hover:text-[var(--color-primary-dark)] disabled:opacity-40"
+                  >
+                    卸载
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* 卸载执行中遮罩 */}
+      <AnimatePresence>
+        {busy && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 z-20 flex items-center justify-center bg-black/20"
+          >
+            <div className="flex items-center gap-3 rounded-2xl bg-[var(--color-surface)] px-6 py-4 shadow-[var(--shadow-card)]">
+              <Loader2 size={20} className="animate-spin text-[var(--color-primary)]" />
+              <span className="text-sm">{busy}</span>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* 残留清单弹窗 */}
+      <AnimatePresence>
+        {leftover && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 z-30 flex items-center justify-center bg-black/30 p-8"
+            onClick={() => !removing && setLeftover(null)}
+          >
+            <motion.div
+              initial={{ scale: 0.96, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.96, opacity: 0 }}
+              onClick={(e) => e.stopPropagation()}
+              className="flex max-h-full w-full max-w-2xl flex-col overflow-hidden rounded-2xl bg-[var(--color-surface)] shadow-[var(--shadow-card)]"
+            >
+              {/* 弹窗头 */}
+              <div className="border-b border-[var(--color-line)] px-6 py-4">
+                <div className="flex items-center gap-2 text-base font-semibold">
+                  <ShieldCheck size={18} className="text-[var(--color-primary)]" />
+                  卸载完成，发现以下残留
+                </div>
+                <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+                  已卸载：{leftover.appNames.join("、")}。普通文件删入回收站可恢复；系统目录与注册表需管理员授权（会弹一次 UAC），删注册表前自动导出 .reg 备份
+                </p>
+              </div>
+
+              {/* 残留列表 */}
+              <div className="flex-1 overflow-y-auto px-6 py-4">
+                {removeResults ? (
+                  <ResultList results={removeResults} />
+                ) : leftover.items.length === 0 ? (
+                  <div className="py-8 text-center text-sm text-[var(--color-text-secondary)]">
+                    很干净，没有发现明显残留 🎉
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-4">
+                    {dirItems.length > 0 && (
+                      <LeftoverGroup
+                        title="残留文件夹"
+                        icon={<FolderOpen size={15} />}
+                        items={dirItems}
+                        checked={leftoverChecked}
+                        onToggle={toggleLeftover}
+                      />
+                    )}
+                    {regItems.length > 0 && (
+                      <LeftoverGroup
+                        title="残留注册表项"
+                        icon={<KeyRound size={15} />}
+                        items={regItems}
+                        checked={leftoverChecked}
+                        onToggle={toggleLeftover}
+                      />
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {/* 弹窗底部操作 */}
+              <div className="flex items-center justify-end gap-3 border-t border-[var(--color-line)] px-6 py-4">
+                <button
+                  onClick={() => setLeftover(null)}
+                  disabled={removing}
+                  className="rounded-xl px-4 py-2 text-sm text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg)] disabled:opacity-40"
+                >
+                  {removeResults ? "关闭" : "跳过残留"}
+                </button>
+                {!removeResults && leftover.items.length > 0 && (
+                  <button
+                    onClick={removeLeftovers}
+                    disabled={removing || leftoverChecked.size === 0}
+                    className="flex items-center gap-2 rounded-xl bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--color-primary-dark)] disabled:opacity-40"
+                  >
+                    {removing ? <Loader2 size={16} className="animate-spin" /> : <Trash2 size={16} />}
+                    删除选中残留 ({leftoverChecked.size})
+                  </button>
+                )}
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+/** 一组残留项（文件夹 / 注册表） */
+function LeftoverGroup({
+  title,
+  icon,
+  items,
+  checked,
+  onToggle,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  items: LeftoverItem[];
+  checked: Set<string>;
+  onToggle: (key: string) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-[var(--color-text-secondary)]">
+        {icon}
+        {title}（{items.length}）
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {items.map((it) => {
+          const key = leftoverKey(it);
+          const low = it.confidence === "low";
+          return (
+            <label
+              key={key}
+              className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-[var(--color-line)] bg-[var(--color-bg)] px-3 py-2"
+            >
+              <input
+                type="checkbox"
+                checked={checked.has(key)}
+                onChange={() => onToggle(key)}
+                className="h-4 w-4 shrink-0 accent-[var(--color-primary)]"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-xs text-[var(--color-text-main)]" title={it.path}>
+                  {it.path}
+                </div>
+              </div>
+              {low ? (
+                <span className="flex shrink-0 items-center gap-1 text-[11px] text-[var(--color-caution)]">
+                  <AlertTriangle size={12} />
+                  谨慎
+                </span>
+              ) : (
+                it.kind === "dir" &&
+                it.size > 0 && (
+                  <span className="shrink-0 text-[11px] text-[var(--color-text-secondary)]">
+                    {formatBytes(it.size)}
+                  </span>
+                )
+              )}
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** 删除结果列表 */
+function ResultList({ results }: { results: RemoveResult[] }) {
+  const ok = results.filter((r) => r.ok).length;
+  const fail = results.length - ok;
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="text-sm">
+        已删除 <span className="font-semibold text-[var(--color-safe)]">{ok}</span> 项
+        {fail > 0 && (
+          <>
+            ，<span className="font-semibold text-[var(--color-caution)]">{fail}</span> 项未成功
+          </>
+        )}
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {results.map((r) => (
+          <div
+            key={r.path}
+            className="flex items-center gap-2 rounded-lg border border-[var(--color-line)] bg-[var(--color-bg)] px-3 py-2"
+          >
+            {r.ok ? (
+              <CheckCircle2 size={14} className="shrink-0 text-[var(--color-safe)]" />
+            ) : (
+              <XCircle size={14} className="shrink-0 text-[var(--color-caution)]" />
+            )}
+            <span className="min-w-0 flex-1 truncate text-xs" title={r.path}>
+              {r.path}
+            </span>
+            {!r.ok && r.error && (
+              <span className="shrink-0 text-[11px] text-[var(--color-caution)]">{r.error}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Uninstall.tsx
+++ b/src/pages/Uninstall.tsx
@@ -52,9 +52,23 @@ export default function Uninstall() {
   const requestedIcons = useRef<Set<string>>(new Set());
 
   async function load(): Promise<InstalledApp[]> {
-    const list = await invoke<InstalledApp[]>("list_installed_apps");
-    setApps(list);
-    return list;
+    // Win32（注册表）瞬时返回，先渲染；UWP 较慢，随后合并
+    const win32 = await invoke<InstalledApp[]>("list_installed_apps");
+    setApps(win32);
+    let uwp: InstalledApp[] = [];
+    try {
+      uwp = await invoke<InstalledApp[]>("list_uwp_apps");
+    } catch {
+      /* UWP 枚举失败不影响主列表 */
+    }
+    const merged =
+      uwp.length === 0
+        ? win32
+        : [...win32, ...uwp].sort((a, b) =>
+            a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+          );
+    setApps(merged);
+    return merged;
   }
 
   /** 轮询等待指定软件从列表消失（很多卸载器子进程异步执行，进程返回时注册表键还在）。 */
@@ -69,8 +83,25 @@ export default function Uninstall() {
   }
 
   useEffect(() => {
-    load()
-      .then(() => setPhase("ready"))
+    // 首屏做到“打开即显示”：Win32（注册表枚举，瞬时）先出并置为 ready，
+    // UWP（Get-AppxPackage 较慢）后台异步追加，避免开屏等待。
+    invoke<InstalledApp[]>("list_installed_apps")
+      .then((win32) => {
+        setApps(win32);
+        setPhase("ready");
+        invoke<InstalledApp[]>("list_uwp_apps")
+          .then((uwp) => {
+            if (uwp.length === 0) return;
+            setApps((prev) => {
+              const ids = new Set(prev.map((a) => a.id));
+              const add = uwp.filter((u) => !ids.has(u.id));
+              return [...prev, ...add].sort((a, b) =>
+                a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+              );
+            });
+          })
+          .catch(() => {});
+      })
       .catch((e) => {
         setError(String(e));
         setPhase("ready");

--- a/src/pages/Uninstall.tsx
+++ b/src/pages/Uninstall.tsx
@@ -13,8 +13,10 @@ import {
   AlertTriangle,
   CheckCircle2,
   XCircle,
+  Zap,
 } from "lucide-react";
 import { InstalledApp, LeftoverItem, RemoveResult, formatBytes } from "../types";
+import ForceDeleteModal from "../components/ForceDeleteModal";
 
 type Phase = "loading" | "ready";
 
@@ -42,6 +44,8 @@ export default function Uninstall() {
   const [leftoverChecked, setLeftoverChecked] = useState<Set<string>>(new Set());
   const [removing, setRemoving] = useState(false);
   const [removeResults, setRemoveResults] = useState<RemoveResult[] | null>(null);
+  /** 强力删除弹窗目标路径（残留删除失败时，关闭占用进程后再删） */
+  const [forceTarget, setForceTarget] = useState<string | null>(null);
 
   /** 图标缓存：按 app.id（回退会用到 installLocation，不能只按 iconPath 缓存） */
   const [icons, setIcons] = useState<Record<string, string>>({});
@@ -407,7 +411,7 @@ export default function Uninstall() {
               {/* 残留列表 */}
               <div className="flex-1 overflow-y-auto px-6 py-4">
                 {removeResults ? (
-                  <ResultList results={removeResults} />
+                  <ResultList results={removeResults} onForceDelete={setForceTarget} />
                 ) : leftover.items.length === 0 ? (
                   <div className="py-8 text-center text-sm text-[var(--color-text-secondary)]">
                     很干净，没有发现明显残留 🎉
@@ -458,6 +462,21 @@ export default function Uninstall() {
               </div>
             </motion.div>
           </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* 强力删除弹窗：残留删除失败被占用时，关闭占用进程后再删 */}
+      <AnimatePresence>
+        {forceTarget && (
+          <ForceDeleteModal
+            path={forceTarget}
+            onClose={() => setForceTarget(null)}
+            onDeleted={(p) =>
+              setRemoveResults((prev) =>
+                prev ? prev.map((r) => (r.path === p ? { ...r, ok: true, error: null } : r)) : prev,
+              )
+            }
+          />
         )}
       </AnimatePresence>
     </div>
@@ -526,7 +545,13 @@ function LeftoverGroup({
 }
 
 /** 删除结果列表 */
-function ResultList({ results }: { results: RemoveResult[] }) {
+function ResultList({
+  results,
+  onForceDelete,
+}: {
+  results: RemoveResult[];
+  onForceDelete: (path: string) => void;
+}) {
   const ok = results.filter((r) => r.ok).length;
   const fail = results.length - ok;
   return (
@@ -555,6 +580,15 @@ function ResultList({ results }: { results: RemoveResult[] }) {
             </span>
             {!r.ok && r.error && (
               <span className="shrink-0 text-[11px] text-[var(--color-caution)]">{r.error}</span>
+            )}
+            {!r.ok && !/^(HKEY|HKCU|HKLM|HKCR|HKU)/i.test(r.path) && (
+              <button
+                onClick={() => onForceDelete(r.path)}
+                className="flex shrink-0 items-center gap-1 rounded-lg border border-[var(--color-caution)] px-2 py-1 text-[11px] text-[var(--color-caution)] transition-colors hover:bg-[var(--color-caution)] hover:text-white"
+              >
+                <Zap size={11} />
+                强力删除
+              </button>
             )}
           </div>
         ))}

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,3 +236,35 @@ export function formatAgo(unixSecs: number): string {
   if (diff < 86400) return `${Math.floor(diff / 3600)} 小时前`;
   return `${Math.floor(diff / 86400)} 天前`;
 }
+
+// ---------- 软件卸载（类 Geek Uninstaller） ----------
+
+/** 一个已安装的桌面软件（与 Rust uninstall::InstalledApp 对应） */
+export interface InstalledApp {
+  id: string;
+  name: string;
+  version: string;
+  publisher: string;
+  installLocation: string;
+  iconPath: string;
+  size: number;
+  hasQuiet: boolean;
+  uninstallString: string;
+}
+
+/** 卸载后扫出的单个残留项 */
+export interface LeftoverItem {
+  /** "dir" 文件夹 | "reg" 注册表项 */
+  kind: "dir" | "reg";
+  path: string;
+  size: number;
+  /** "high" 高置信度 | "low" 需谨慎（默认不勾） */
+  confidence: "high" | "low";
+}
+
+/** 单项残留删除结果 */
+export interface RemoveResult {
+  path: string;
+  ok: boolean;
+  error: string | null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,3 +268,13 @@ export interface RemoveResult {
   ok: boolean;
   error: string | null;
 }
+
+// ---------- 强力删除（Restart Manager 定位占用进程） ----------
+
+/** 占用某文件/文件夹的进程（与 Rust force_delete::LockingProcess 对应） */
+export interface LockingProcess {
+  pid: number;
+  name: string;
+  /** 系统关键进程：禁止终止 */
+  isCritical: boolean;
+}


### PR DESCRIPTION
## 本 PR 包含三块功能

### 1. 软件卸载（类 Geek Uninstaller）
- 枚举已装软件（含 UWP 商店应用），调用原生卸载器，卸载后扫描并清理残留（文件夹 + 注册表）
- 注册表删除前自动导出 .reg 备份；文件默认进回收站可恢复；支持批量卸载
- 图标来源多级兜底：DisplayIcon → MSI 产品图标 → 安装目录/卸载器主 exe

### 2. 强力删除（解决"文件正在使用/删不掉"）
- 用 NtQueryInformationFile(FileProcessIdsUsingFileInformation) + Restart Manager 定位占用进程
- 解锁链：DUPLICATE_CLOSE_SOURCE 关句柄→立即删；仍占用则结束整个占用应用后删
- 系统关键进程（explorer/lsass 等）受保护，不可关闭；支持拖拽/粘贴路径

### 3. 卸载体验与图标优化
- 两阶段加载：Win32 秒出、UWP 后台追加，打开即显示
- UWP 枚举改读 AppxManifest.xml，提速约 20 倍
- 图标提取首选 PrivateExtractIconsW，修复微信等现代图标不显示

全部 71+ 后端测试通过，tsc 通过。